### PR TITLE
添加聊天过滤功能并改进HUD界面

### DIFF
--- a/src/engine/shared/config_variables_tclient.h
+++ b/src/engine/shared/config_variables_tclient.h
@@ -437,3 +437,12 @@ MACRO_CONFIG_INT(QmStreamerScoreboardDefaultFlags, qm_streamer_scoreboard_defaul
 MACRO_CONFIG_INT(QmFriendOnlineNotify, qm_friend_online_notify, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "好友上线提醒")
 MACRO_CONFIG_INT(QmFriendOnlineAutoRefresh, qm_friend_online_auto_refresh, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "好友提醒自动刷新服务器列表")
 MACRO_CONFIG_INT(QmFriendOnlineRefreshSeconds, qm_friend_online_refresh_seconds, 30, 5, 300, CFGFLAG_CLIENT | CFGFLAG_SAVE, "好友提醒刷新间隔(秒)")
+
+// Block Words / 屏蔽词
+MACRO_CONFIG_INT(QmBlockWordsEnabled, qm_block_words_enabled, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "启用屏蔽词列表")
+MACRO_CONFIG_INT(QmBlockWordsShowConsole, qm_block_words_show_console, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "控制台显示被屏蔽词")
+MACRO_CONFIG_COL(QmBlockWordsConsoleColor, qm_block_words_console_color, 0xFFFFFFFF, CFGFLAG_CLIENT | CFGFLAG_SAVE, "被屏蔽词控制台颜色")
+MACRO_CONFIG_INT(QmBlockWordsMultiReplace, qm_block_words_multi_replace, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "按屏蔽词长度多字符替换")
+MACRO_CONFIG_INT(QmBlockWordsMode, qm_block_words_mode, 2, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE, "替换方式 0=Regex 1=Full 2=Both")
+MACRO_CONFIG_STR(QmBlockWordsReplacementChar, qm_block_words_replacement_char, 8, "*", CFGFLAG_CLIENT | CFGFLAG_SAVE, "屏蔽词替换字符")
+MACRO_CONFIG_STR(QmBlockWordsList, qm_block_words_list, 1024, "", CFGFLAG_CLIENT | CFGFLAG_SAVE, "屏蔽词列表（用,分隔）")

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -3,6 +3,8 @@
 
 #include "chat.h"
 
+#include <base/log.h>
+
 #include <engine/editor.h>
 #include <engine/external/regex.h>
 #include <engine/graphics.h>
@@ -23,9 +25,201 @@
 #include <game/client/gameclient.h>
 #include <game/localization.h>
 
+#include <algorithm>
 #include <cmath>
 
 char CChat::ms_aDisplayText[MAX_LINE_LENGTH] = "";
+
+enum
+{
+	BLOCK_WORDS_MODE_REGEX = 0,
+	BLOCK_WORDS_MODE_FULL,
+	BLOCK_WORDS_MODE_BOTH
+};
+
+static int BlockWordsSeparatorLength(const char *pStr)
+{
+	const unsigned char C0 = (unsigned char)pStr[0];
+	if(C0 == ',' || C0 == ';' || C0 == '|' || C0 == '\n' || C0 == '\r')
+		return 1;
+	if(C0 == 0xEF && (unsigned char)pStr[1] == 0xBC)
+	{
+		const unsigned char C2 = (unsigned char)pStr[2];
+		if(C2 == 0x8C || C2 == 0x9B)
+			return 3;
+	}
+	return 0;
+}
+
+static void ParseBlockWordsList(const char *pList, std::vector<std::string> &OutWords)
+{
+	OutWords.clear();
+	if(!pList || pList[0] == '\0')
+		return;
+
+	char aBuf[1024];
+	str_copy(aBuf, pList, sizeof(aBuf));
+	char *pCursor = aBuf;
+
+	while(*pCursor)
+	{
+		int SepLen = BlockWordsSeparatorLength(pCursor);
+		while(*pCursor && SepLen > 0)
+		{
+			pCursor += SepLen;
+			SepLen = BlockWordsSeparatorLength(pCursor);
+		}
+
+		char *pStart = pCursor;
+		while(*pCursor && BlockWordsSeparatorLength(pCursor) == 0)
+			pCursor++;
+
+		if(pStart == pCursor)
+			break;
+
+		if(*pCursor)
+		{
+			const int CutLen = BlockWordsSeparatorLength(pCursor);
+			*pCursor = '\0';
+			pCursor += CutLen;
+		}
+
+		char *pToken = (char *)str_utf8_skip_whitespaces(pStart);
+		str_utf8_trim_right(pToken);
+		if(pToken[0] != '\0')
+			OutWords.emplace_back(pToken);
+	}
+}
+
+static void PushUniqueWord(std::vector<std::string> &OutWords, const std::string &Word)
+{
+	if(std::find(OutWords.begin(), OutWords.end(), Word) == OutWords.end())
+		OutWords.push_back(Word);
+}
+
+struct CBlockWordsCache
+{
+	std::string m_List;
+	int m_Mode = -1;
+	std::vector<std::string> m_Words;
+	std::vector<Regex> m_Regexes;
+};
+
+static void UpdateBlockWordsCache(CBlockWordsCache &Cache)
+{
+	if(Cache.m_List == g_Config.m_QmBlockWordsList && Cache.m_Mode == g_Config.m_QmBlockWordsMode)
+		return;
+
+	Cache.m_List = g_Config.m_QmBlockWordsList;
+	Cache.m_Mode = g_Config.m_QmBlockWordsMode;
+
+	ParseBlockWordsList(Cache.m_List.c_str(), Cache.m_Words);
+	Cache.m_Regexes.clear();
+
+	if(Cache.m_Mode == BLOCK_WORDS_MODE_REGEX || Cache.m_Mode == BLOCK_WORDS_MODE_BOTH)
+	{
+		Cache.m_Regexes.reserve(Cache.m_Words.size());
+		for(const auto &Pattern : Cache.m_Words)
+		{
+			Regex Re(Pattern);
+			if(!Re.error().empty())
+			{
+				log_error("blocklist", "Invalid regex: %s", Pattern.c_str());
+				continue;
+			}
+			Cache.m_Regexes.push_back(std::move(Re));
+		}
+	}
+}
+
+static bool ReplaceLiteralWords(std::string &Text, const std::vector<std::string> &Words, char Replacement, bool MultiReplace, std::vector<std::string> *pMatched)
+{
+	bool AnyReplaced = false;
+
+	for(const auto &Word : Words)
+	{
+		if(Word.empty())
+			continue;
+
+		std::string Result;
+		const char *pCursor = Text.c_str();
+		const char *pMatchEnd = nullptr;
+		bool WordReplaced = false;
+
+		while(const char *pMatch = str_utf8_find_nocase(pCursor, Word.c_str(), &pMatchEnd))
+		{
+			Result.append(pCursor, pMatch - pCursor);
+			if(MultiReplace)
+				Result.append(pMatchEnd - pMatch, Replacement);
+			else
+				Result.push_back(Replacement);
+			pCursor = pMatchEnd;
+			WordReplaced = true;
+		}
+
+		if(WordReplaced)
+		{
+			Result.append(pCursor);
+			Text.swap(Result);
+			AnyReplaced = true;
+			if(pMatched)
+				PushUniqueWord(*pMatched, Word);
+		}
+	}
+
+	return AnyReplaced;
+}
+
+static bool ReplaceRegexWords(std::string &Text, std::vector<Regex> &Regexes, char Replacement, bool MultiReplace, std::vector<std::string> *pMatched)
+{
+	bool AnyReplaced = false;
+
+	for(Regex &Re : Regexes)
+	{
+		bool RegexMatched = false;
+		std::string Result = Re.replace(Text, true, [&](const std::string &Str, int, int Group) {
+			if(Group != 0)
+				return std::string();
+			RegexMatched = true;
+			if(pMatched)
+				PushUniqueWord(*pMatched, Str);
+			if(MultiReplace)
+				return std::string(Str.size(), Replacement);
+			return std::string(1, Replacement);
+		});
+
+		if(RegexMatched)
+		{
+			Text.swap(Result);
+			AnyReplaced = true;
+		}
+	}
+
+	return AnyReplaced;
+}
+
+static bool ApplyBlockWords(std::string &Text, std::vector<std::string> *pMatched)
+{
+	if(!g_Config.m_QmBlockWordsEnabled || g_Config.m_QmBlockWordsList[0] == '\0')
+		return false;
+
+	static CBlockWordsCache s_Cache;
+	UpdateBlockWordsCache(s_Cache);
+	if(s_Cache.m_Words.empty())
+		return false;
+
+	const char Replacement = g_Config.m_QmBlockWordsReplacementChar[0] != '\0' ? g_Config.m_QmBlockWordsReplacementChar[0] : '*';
+	const bool MultiReplace = g_Config.m_QmBlockWordsMultiReplace != 0;
+	const int Mode = g_Config.m_QmBlockWordsMode;
+
+	bool Replaced = false;
+	if(Mode == BLOCK_WORDS_MODE_REGEX || Mode == BLOCK_WORDS_MODE_BOTH)
+		Replaced |= ReplaceRegexWords(Text, s_Cache.m_Regexes, Replacement, MultiReplace, pMatched);
+	if(Mode == BLOCK_WORDS_MODE_FULL || Mode == BLOCK_WORDS_MODE_BOTH)
+		Replaced |= ReplaceLiteralWords(Text, s_Cache.m_Words, Replacement, MultiReplace, pMatched);
+
+	return Replaced;
+}
 
 CChat::CLine::CLine()
 {
@@ -806,6 +1000,35 @@ void CChat::AddLine(int ClientId, int Team, const char *pLine)
 	// TClient
 	if(ClientId == CLIENT_MSG && !g_Config.m_TcShowChatClient)
 		return;
+
+	char aFilteredLine[MAX_LINE_LENGTH];
+	const char *pFilteredLine = pLine;
+	std::vector<std::string> BlockedWords;
+	if(g_Config.m_QmBlockWordsEnabled && g_Config.m_QmBlockWordsList[0] != '\0')
+	{
+		std::string Text = pLine;
+		std::vector<std::string> *pMatched = g_Config.m_QmBlockWordsShowConsole ? &BlockedWords : nullptr;
+		if(ApplyBlockWords(Text, pMatched))
+		{
+			str_copy(aFilteredLine, Text.c_str(), sizeof(aFilteredLine));
+			pFilteredLine = aFilteredLine;
+			if(g_Config.m_QmBlockWordsShowConsole && !BlockedWords.empty())
+			{
+				std::string Joined;
+				for(size_t i = 0; i < BlockedWords.size(); ++i)
+				{
+					if(i > 0)
+						Joined.append(", ");
+					Joined.append(BlockedWords[i]);
+				}
+				char aBuf[512];
+				str_format(aBuf, sizeof(aBuf), "屏蔽词: %s", Joined.c_str());
+				const ColorRGBA LogColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_QmBlockWordsConsoleColor));
+				Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "chat/blocklist", aBuf, LogColor);
+			}
+		}
+	}
+	pLine = pFilteredLine;
 
 	// trim right and set maximum length to 256 utf8-characters
 	int Length = 0;

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -1569,6 +1569,58 @@ void CHud::RenderDummyActions()
 	Graphics()->RenderQuadContainerAsSprite(m_HudQuadContainerIndex, m_DummyCopyOffset, x, y);
 }
 
+void CHud::RenderKeyStatus()
+{
+	const float Fontsize = 7.0f;
+	const float LineHeight = 9.0f;
+	const float PaddingX = 4.0f;
+	const float PaddingY = 3.0f;
+	const float StartX = 4.0f;
+	const float StartY = 45.0f;
+
+	const char *pKeyStatusText = "卡键: ?";
+	if(g_Config.m_ClDummyResetOnSwitch == 0)
+		pKeyStatusText = "卡键: ON";
+	else if(g_Config.m_ClDummyResetOnSwitch == 1)
+		pKeyStatusText = "卡键: OFF";
+	else if(g_Config.m_ClDummyResetOnSwitch == 2)
+		pKeyStatusText = "卡键: 重置本体";
+
+	const bool FirePressed = (GameClient()->m_Controls.m_aInputData[g_Config.m_ClDummy].m_Fire & 1) != 0;
+	const char *pHammerState = g_Config.m_ClDummyHammer ? (FirePressed ? "DF" : "HDF") : "正常锤";
+	char aHammerLine[64];
+	str_format(aHammerLine, sizeof(aHammerLine), "锤: %s", pHammerState);
+
+	const char *pControlState = g_Config.m_ClDummyControl ? "开启" : "关闭";
+	char aControlLine[64];
+	str_format(aControlLine, sizeof(aControlLine), "分身控制: %s", pControlState);
+
+	float BoxWidth = TextRender()->TextWidth(Fontsize, pKeyStatusText, -1, -1.0f);
+	BoxWidth = maximum(BoxWidth, TextRender()->TextWidth(Fontsize, aHammerLine, -1, -1.0f));
+	BoxWidth = maximum(BoxWidth, TextRender()->TextWidth(Fontsize, aControlLine, -1, -1.0f));
+	BoxWidth += PaddingX * 2.0f;
+
+	const float BoxHeight = LineHeight * 3.0f + PaddingY * 2.0f;
+	Graphics()->DrawRect(StartX, StartY, BoxWidth, BoxHeight, ColorRGBA(0.0f, 0.0f, 0.0f, 0.4f), IGraphics::CORNER_ALL, 5.0f);
+
+	float TextX = StartX + PaddingX;
+	float TextY = StartY + PaddingY;
+
+	const float Time = Client()->GlobalTime();
+	const float Hue = std::fmod(Time * 0.2f, 1.0f);
+	ColorHSLA RainbowHsla(Hue, 0.75f, 0.6f, 1.0f);
+	ColorRGBA RainbowColor = color_cast<ColorRGBA>(RainbowHsla);
+
+	TextRender()->TextColor(RainbowColor);
+	TextRender()->Text(TextX, TextY, Fontsize, pKeyStatusText, -1.0f);
+	TextRender()->TextColor(TextRender()->DefaultTextColor());
+	TextY += LineHeight;
+
+	TextRender()->Text(TextX, TextY, Fontsize, aHammerLine, -1.0f);
+	TextY += LineHeight;
+	TextRender()->Text(TextX, TextY, Fontsize, aControlLine, -1.0f);
+}
+
 inline int CHud::GetDigitsIndex(int Value, int Max)
 {
 	if(Value < 0)
@@ -1596,8 +1648,6 @@ inline float CHud::GetMovementInformationBoxHeight()
 	{
 		BoxHeight += 5.0f * MOVEMENT_INFORMATION_LINE_HEIGHT;
 	}
-	// 新增卡键状态显示行
-	BoxHeight += 1.0f * MOVEMENT_INFORMATION_LINE_HEIGHT;
 	// 新增玩家统计显示行（3行：存活时长、救醒/落水、出钩比例）
 	if(g_Config.m_QmPlayerStatsHud)
 	{
@@ -1912,30 +1962,6 @@ void CHud::RenderMovementInformation()
 		y += MOVEMENT_INFORMATION_LINE_HEIGHT;
 	}
 
-	// 卡键状态显示 (cl_dummy_resetonswitch) - 彩虹动态渐变
-	{
-		const char *pStatusText;
-		if(g_Config.m_ClDummyResetOnSwitch == 0)
-			pStatusText = "卡键: ON";
-		else if(g_Config.m_ClDummyResetOnSwitch == 1)
-			pStatusText = "卡键: OFF";
-		else if(g_Config.m_ClDummyResetOnSwitch == 2)
-			pStatusText = "卡键: 重置本体";
-		else
-			pStatusText = "卡键: ?";
-
-		// 彩虹动态颜色
-		const float Time = Client()->GlobalTime();
-		const float Hue = std::fmod(Time * 0.2f, 1.0f);
-		ColorHSLA RainbowHsla(Hue, 0.75f, 0.6f, 1.0f);
-		ColorRGBA RainbowColor = color_cast<ColorRGBA>(RainbowHsla);
-
-		TextRender()->TextColor(RainbowColor);
-		TextRender()->Text(LeftX, y, Fontsize, pStatusText, -1.0f);
-		TextRender()->TextColor(TextRender()->DefaultTextColor());
-		y += MOVEMENT_INFORMATION_LINE_HEIGHT;
-	}
-
 	// 玩家统计HUD显示
 	if(g_Config.m_QmPlayerStatsHud)
 	{
@@ -2158,6 +2184,7 @@ void CHud::OnRender()
 		if(g_Config.m_ClShowhudScore)
 			RenderScoreHud();
 		RenderDummyActions();
+		RenderKeyStatus();
 		RenderWarmupTimer();
 		RenderTextInfo();
 		GameClient()->m_TClient.RenderCenterLines();

--- a/src/game/client/components/hud.h
+++ b/src/game/client/components/hud.h
@@ -80,6 +80,7 @@ class CHud : public CComponent
 	int m_LastSpectatorCountTick;
 	void RenderSpectatorCount();
 	void RenderDummyActions();
+	void RenderKeyStatus();
 	void RenderMovementInformation();
 
 	void UpdateMovementInformationTextContainer(STextContainerIndex &TextContainer, float FontSize, float Value, float &PrevValue);

--- a/src/game/client/components/menus_settings_controls.cpp
+++ b/src/game/client/components/menus_settings_controls.cpp
@@ -93,15 +93,10 @@ void CMenusSettingsControls::OnInterfacesInit(CGameClient *pClient)
 		{EBindOptionGroup::CHAT, Localizable("Converse"), "+show_chat; chat all /c "},
 		{EBindOptionGroup::CHAT, Localizable("Chat command"), "+show_chat; chat all /"},
 		{EBindOptionGroup::CHAT, Localizable("Show chat"), "+show_chat"},
-		{EBindOptionGroup::CHAT, Localizable("语言转文字"), "+stt"},
 		{EBindOptionGroup::CHAT, Localizable("复读"), "+qm_repeat"},
 		{EBindOptionGroup::DUMMY, Localizable("Toggle dummy"), "toggle cl_dummy 0 1"},
 		{EBindOptionGroup::DUMMY, Localizable("Dummy copy"), "toggle cl_dummy_copy_moves 0 1"},
 		{EBindOptionGroup::DUMMY, Localizable("Hammerfly dummy"), "toggle cl_dummy_hammer 0 1"},
-		//自定义BIND
-		//{EBindOptionGroup::COMMON_BINDS, Localizable("八角定位"), "echo 你正在使用45度瞄准;+toggle cl_mouse_max_distance 2 400; +toggle_restore inp_mousesens 1"},
-
-		//自定义BIND END
 		{EBindOptionGroup::MISCELLANEOUS, Localizable("Emoticon"), "+emote"},
 		{EBindOptionGroup::MISCELLANEOUS, Localizable("Spectator mode"), "+spectate"},
 		{EBindOptionGroup::MISCELLANEOUS, Localizable("Spectate next"), "spectate_next"},
@@ -194,7 +189,7 @@ void CMenusSettingsControls::Render(CUIRect MainView)
 	RenderSettingsBlock(MeasureSettingsMouseHeight(), &LeftColumn,
 		Localize("Mouse"), nullptr, nullptr, std::bind_front(&CMenusSettingsControls::RenderSettingsMouse, this));
 	RenderSettingsBlock(MeasureSettingsJoystickHeight(), &LeftColumn,
-		Localizable("Controller"), nullptr, nullptr, std::bind_front(&CMenusSettingsControls::RenderSettingsJoystick, this));
+		Localizable("手柄"), nullptr, nullptr, std::bind_front(&CMenusSettingsControls::RenderSettingsJoystick, this));
 	RenderSettingsBindsBlock(EBindOptionGroup::MOVEMENT, &LeftColumn, Localize("Movement"));
 	RenderSettingsBindsBlock(EBindOptionGroup::WEAPON, &LeftColumn, Localize("Weapon"));
 
@@ -202,7 +197,6 @@ void CMenusSettingsControls::Render(CUIRect MainView)
 	RenderSettingsBindsBlock(EBindOptionGroup::VOTING, &RightColumn, Localize("Voting"));
 	RenderSettingsBindsBlock(EBindOptionGroup::CHAT, &RightColumn, Localize("Chat"));
 	RenderSettingsBindsBlock(EBindOptionGroup::DUMMY, &RightColumn, Localize("Dummy"));
-	RenderSettingsBindsBlock(EBindOptionGroup::COMMON_BINDS, &RightColumn, Localize("常用Bind"));
 	RenderSettingsBindsBlock(EBindOptionGroup::MISCELLANEOUS, &RightColumn, Localize("Miscellaneous"));
 	if(std::any_of(m_vBindOptions.begin(), m_vBindOptions.end(), [](const CBindOption &Option) { return Option.m_Group == EBindOptionGroup::CUSTOM; }))
 	{

--- a/src/game/client/components/menus_settings_controls.h
+++ b/src/game/client/components/menus_settings_controls.h
@@ -18,7 +18,6 @@ enum class EBindOptionGroup
 	VOTING,
 	CHAT,
 	DUMMY,
-	COMMON_BINDS,
 	MISCELLANEOUS,
 	CUSTOM,
 	NUM,

--- a/src/game/client/components/tclient/menus_qmclient.cpp
+++ b/src/game/client/components/tclient/menus_qmclient.cpp
@@ -3487,6 +3487,19 @@ void CMenus::RenderSettingsQiMeng(CUIRect MainView)
 		s_ReaderButtonSmallSens, s_ClearButtonSmallSens,
 		s_ReaderButtonLeftJump, s_ClearButtonLeftJump,
 		s_ReaderButtonRightJump, s_ClearButtonRightJump;
+	static int s_Toggle45Degrees = 0;
+	static int s_ToggleSmallSens = 0;
+	static int s_PrevMouseMaxDistance = -1;
+	static int s_PrevMouseSens = -1;
+	static bool s_TogglesInitialized = false;
+	if(!s_TogglesInitialized)
+	{
+		s_Toggle45Degrees = g_Config.m_ClMouseMaxDistance == 2;
+		s_ToggleSmallSens = g_Config.m_InpMousesens == 1;
+		s_PrevMouseMaxDistance = s_Toggle45Degrees ? 400 : g_Config.m_ClMouseMaxDistance;
+		s_PrevMouseSens = s_ToggleSmallSens ? 200 : g_Config.m_InpMousesens;
+		s_TogglesInitialized = true;
+	}
 
 	DoKeyBindRow(CardContent, s_ReaderButtonDummyPseudo, s_ClearButtonDummyPseudo,
 		TCLocalize("HDF"), "+toggle cl_dummy_hammer 1 0");
@@ -3494,8 +3507,50 @@ void CMenus::RenderSettingsQiMeng(CUIRect MainView)
 		TCLocalize("DF"), "+fire; +toggle cl_dummy_hammer 1 0");
 	DoKeyBindRow(CardContent, s_ReaderButton45Degrees, s_ClearButton45Degrees,
 		TCLocalize("八角定位"), "echo 你正在使用45度瞄准;+toggle cl_mouse_max_distance 2 400; +toggle_restore inp_mousesens 1");
+	{
+		CUIRect ToggleRow, ToggleLabel;
+		CardContent.HSplitTop(LG_LineHeight, &ToggleRow, &CardContent);
+		ToggleRow.VSplitLeft(LG_LabelWidth, &ToggleLabel, nullptr);
+		ToggleLabel.VSplitLeft(LG_LineHeight, nullptr, &ToggleLabel);
+		if(DoButton_CheckBox(&s_Toggle45Degrees, TCLocalize("按下切换"), s_Toggle45Degrees, &ToggleLabel))
+		{
+			s_Toggle45Degrees ^= 1;
+			if(s_Toggle45Degrees)
+			{
+				if(g_Config.m_ClMouseMaxDistance != 2)
+					s_PrevMouseMaxDistance = g_Config.m_ClMouseMaxDistance;
+				g_Config.m_ClMouseMaxDistance = 2;
+			}
+			else
+			{
+				g_Config.m_ClMouseMaxDistance = s_PrevMouseMaxDistance >= 0 ? s_PrevMouseMaxDistance : 400;
+			}
+		}
+		CardContent.HSplitTop(LG_LineSpacing, nullptr, &CardContent);
+	}
 	DoKeyBindRow(CardContent, s_ReaderButtonSmallSens, s_ClearButtonSmallSens,
 		TCLocalize("瞄缝救人"), "+toggle_restore inp_mousesens 1");
+	{
+		CUIRect ToggleRow, ToggleLabel;
+		CardContent.HSplitTop(LG_LineHeight, &ToggleRow, &CardContent);
+		ToggleRow.VSplitLeft(LG_LabelWidth, &ToggleLabel, nullptr);
+		ToggleLabel.VSplitLeft(LG_LineHeight, nullptr, &ToggleLabel);
+		if(DoButton_CheckBox(&s_ToggleSmallSens, TCLocalize("按下切换"), s_ToggleSmallSens, &ToggleLabel))
+		{
+			s_ToggleSmallSens ^= 1;
+			if(s_ToggleSmallSens)
+			{
+				if(g_Config.m_InpMousesens != 1)
+					s_PrevMouseSens = g_Config.m_InpMousesens;
+				g_Config.m_InpMousesens = 1;
+			}
+			else
+			{
+				g_Config.m_InpMousesens = s_PrevMouseSens > 0 ? s_PrevMouseSens : 200;
+			}
+		}
+		CardContent.HSplitTop(LG_LineSpacing, nullptr, &CardContent);
+	}
 	DoKeyBindRow(CardContent, s_ReaderButtonLeftJump, s_ClearButtonLeftJump,
 		TCLocalize("三格左跳"), "+jump; +left");
 	DoKeyBindRow(CardContent, s_ReaderButtonRightJump, s_ClearButtonRightJump,
@@ -3651,6 +3706,105 @@ void CMenus::RenderSettingsQiMeng(CUIRect MainView)
 		Ui()->DoScrollbarOption(&g_Config.m_QmFriendOnlineRefreshSeconds, &g_Config.m_QmFriendOnlineRefreshSeconds, &Row, TCLocalize("刷新间隔"), 5, 300, &CUi::ms_LinearScrollbarScale, 0, "s");
 		CardContent.HSplitTop(LG_LineSpacing, nullptr, &CardContent);
 	}
+
+	CardContent.HSplitTop(LG_CardPadding, nullptr, &CardContent);
+	Column.y = CardContent.y;
+	s_GlassCards.back().h = Column.y - s_GlassCards.back().y;
+
+	// ========== 模块 3.95: 屏蔽词 ==========
+	Column.HSplitTop(LG_CardSpacing, nullptr, &Column);
+	CUIRect CardBlockWordsStart = Column;
+	s_GlassCards.push_back(CardBlockWordsStart);
+
+	Column.HSplitTop(LG_CardPadding, nullptr, &Column);
+	Column.VSplitLeft(LG_CardPadding, nullptr, &CardContent);
+	CardContent.VSplitRight(LG_CardPadding, &CardContent, nullptr);
+
+	CardContent.HSplitTop(LG_HeadlineSize, &HeadlineRect, &CardContent);
+	TextRender()->TextColor(GetRainbowColor(7));
+	Ui()->DoLabel(&HeadlineRect, TCLocalize("屏蔽词"), LG_HeadlineSize, TEXTALIGN_ML);
+	TextRender()->TextColor(TextRender()->DefaultTextColor());
+	CardContent.HSplitTop(LG_HeadlineMargin, nullptr, &CardContent);
+
+	CardContent.HSplitTop(LG_LineHeight, &Row, &CardContent);
+	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_QmBlockWordsShowConsole, TCLocalize("控制台显示屏蔽词"), &g_Config.m_QmBlockWordsShowConsole, &Row, LG_LineHeight);
+	CardContent.HSplitTop(LG_LineSpacing, nullptr, &CardContent);
+
+	static CButtonContainer s_BlockWordsConsoleColorId;
+	DoLine_ColorPicker(&s_BlockWordsConsoleColorId, LG_LineHeight, LG_BodySize, LG_LineSpacing, &CardContent, TCLocalize("控制台颜色"), &g_Config.m_QmBlockWordsConsoleColor, ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f), false);
+
+	CardContent.HSplitTop(LG_LineHeight, &Row, &CardContent);
+	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_QmBlockWordsEnabled, TCLocalize("启用屏蔽词列表"), &g_Config.m_QmBlockWordsEnabled, &Row, LG_LineHeight);
+	CardContent.HSplitTop(LG_LineSpacing, nullptr, &CardContent);
+
+	CardContent.HSplitTop(LG_LineHeight, &Row, &CardContent);
+	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_QmBlockWordsMultiReplace, TCLocalize("按词长多字符替换"), &g_Config.m_QmBlockWordsMultiReplace, &Row, LG_LineHeight);
+	CardContent.HSplitTop(LG_LineSpacing, nullptr, &CardContent);
+
+	static CLineInputBuffered<8> s_BlockWordsReplaceInput;
+	static bool s_BlockWordsReplaceInited = false;
+	if(!s_BlockWordsReplaceInited)
+	{
+		s_BlockWordsReplaceInput.Set(g_Config.m_QmBlockWordsReplacementChar);
+		s_BlockWordsReplaceInited = true;
+	}
+	else if(!s_BlockWordsReplaceInput.IsActive() && str_comp(s_BlockWordsReplaceInput.GetString(), g_Config.m_QmBlockWordsReplacementChar) != 0)
+	{
+		s_BlockWordsReplaceInput.Set(g_Config.m_QmBlockWordsReplacementChar);
+	}
+	s_BlockWordsReplaceInput.SetEmptyText("*");
+
+	CardContent.HSplitTop(LG_LineHeight, &Row, &CardContent);
+	Row.VSplitLeft(LG_LabelWidth, &LabelCol, &ControlCol);
+	Ui()->DoLabel(&LabelCol, TCLocalize("替换字符"), LG_BodySize, TEXTALIGN_ML);
+	if(Ui()->DoEditBox(&s_BlockWordsReplaceInput, &ControlCol, LG_BodySize))
+	{
+		char aReplacement[8];
+		str_utf8_truncate(aReplacement, sizeof(aReplacement), s_BlockWordsReplaceInput.GetString(), 1);
+		if(aReplacement[0] == '\0')
+			str_copy(aReplacement, "*", sizeof(aReplacement));
+		str_copy(g_Config.m_QmBlockWordsReplacementChar, aReplacement, sizeof(g_Config.m_QmBlockWordsReplacementChar));
+	}
+	CardContent.HSplitTop(LG_LineSpacing, nullptr, &CardContent);
+
+	CardContent.HSplitTop(LG_LineHeight, &Row, &CardContent);
+	Row.VSplitLeft(LG_LabelWidth, &LabelCol, &ControlCol);
+	Ui()->DoLabel(&LabelCol, TCLocalize("替换方式"), LG_BodySize, TEXTALIGN_ML);
+	CUIRect ModeRow = ControlCol;
+	CUIRect ModeButton;
+	static CButtonContainer s_BlockWordsModeRegex, s_BlockWordsModeFull, s_BlockWordsModeBoth;
+	const float ModeWidth = ModeRow.w / 3.0f;
+	ModeRow.VSplitLeft(ModeWidth, &ModeButton, &ModeRow);
+	if(DoButtonLineSize_Menu(&s_BlockWordsModeRegex, TCLocalize("正则"), g_Config.m_QmBlockWordsMode == 0, &ModeButton, LG_LineHeight, false, 0, IGraphics::CORNER_L, 5.0f, 0.0f, ColorRGBA(0.0f, 0.0f, 0.0f, 0.25f)))
+		g_Config.m_QmBlockWordsMode = 0;
+	ModeRow.VSplitLeft(ModeWidth, &ModeButton, &ModeRow);
+	if(DoButtonLineSize_Menu(&s_BlockWordsModeFull, TCLocalize("字面"), g_Config.m_QmBlockWordsMode == 1, &ModeButton, LG_LineHeight, false, 0, IGraphics::CORNER_NONE, 5.0f, 0.0f, ColorRGBA(0.0f, 0.0f, 0.0f, 0.25f)))
+		g_Config.m_QmBlockWordsMode = 1;
+	if(DoButtonLineSize_Menu(&s_BlockWordsModeBoth, TCLocalize("两者"), g_Config.m_QmBlockWordsMode == 2, &ModeRow, LG_LineHeight, false, 0, IGraphics::CORNER_R, 5.0f, 0.0f, ColorRGBA(0.0f, 0.0f, 0.0f, 0.25f)))
+		g_Config.m_QmBlockWordsMode = 2;
+	CardContent.HSplitTop(LG_LineSpacing, nullptr, &CardContent);
+
+	static CLineInputBuffered<1024> s_BlockWordsInput;
+	static bool s_BlockWordsInited = false;
+	if(!s_BlockWordsInited)
+	{
+		s_BlockWordsInput.Set(g_Config.m_QmBlockWordsList);
+		s_BlockWordsInited = true;
+	}
+	else if(!s_BlockWordsInput.IsActive() && str_comp(s_BlockWordsInput.GetString(), g_Config.m_QmBlockWordsList) != 0)
+	{
+		s_BlockWordsInput.Set(g_Config.m_QmBlockWordsList);
+	}
+	s_BlockWordsInput.SetEmptyText(TCLocalize("用 , 分隔"));
+
+	const float BlockInputWidth = CardContent.w - LG_LabelWidth;
+	const float BlockInputLineSpacing = std::clamp(2.0f * UiScale, 1.0f, 2.0f);
+	const float BlockInputHeight = CalcQiaFenInputHeight(TextRender(), s_BlockWordsInput.GetString(), BlockInputWidth, LG_BodySize, BlockInputLineSpacing, LG_LineHeight);
+	CardContent.HSplitTop(BlockInputHeight, &Row, &CardContent);
+	Row.VSplitLeft(LG_LabelWidth, &LabelCol, &ControlCol);
+	Ui()->DoLabel(&LabelCol, TCLocalize("屏蔽词"), LG_BodySize, TEXTALIGN_ML);
+	if(DoEditBoxMultiLine(Ui(), &s_BlockWordsInput, &ControlCol, LG_BodySize, BlockInputLineSpacing))
+		str_copy(g_Config.m_QmBlockWordsList, s_BlockWordsInput.GetString(), sizeof(g_Config.m_QmBlockWordsList));
 
 	CardContent.HSplitTop(LG_CardPadding, nullptr, &CardContent);
 	Column.y = CardContent.y;


### PR DESCRIPTION
feat(chat): 新增屏蔽词过滤功能并集成到聊天系统中

- 添加屏蔽词列表配置及多种屏蔽模式支持（正则、字面及两者结合）
- 支持多字符替换和替换字符自定义功能
- 实现屏蔽词列表解析、更新缓存和应用过滤的完整逻辑
- 支持在控制台显示被屏蔽词并高亮显示控制台颜色配置
- 配置菜单新增屏蔽词配置界面，支持多行编辑和模式选择
- 聊天组件过滤消息时自动替换屏蔽词
- 新增相关配置项并保存客户端配置

feat(hud): 新增卡键状态HUD显示模块

- 在HUD面板中新增卡键状态显示区域，显示卡键模式、锤子状态及分身控制状态
- 状态文字采用动态彩虹渐变色渲染
- 通过配置项控制卡键状态的显示内容和样式
- 在HUD渲染流程中集成新组件的显示调用

feat(menus_qmclient): 新增屏蔽词设置界面

- 菜单中添加屏蔽词配置面板，包括启用开关、控制台显示选项和控制台颜色选择
- 支持屏蔽词多字符替换开关和替换字符输入
- 支持切换屏蔽词替换模式（正则、字面、两者）
- 支持多行编辑屏蔽词列表，输入依据逗号分隔
- 配合聊天系统屏蔽词功能整体设计调整

refactor(menus_settings_controls): 删除COMMON_BINDS相关绑定接口和配置

- 移除菜单绑定枚举COMMON_BINDS及相关绑定显示
- 清理无用代码，增强菜单绑定模块整洁性