### PR TITLE
feat(friends): 添加好友备注功能和分组展开状态保存

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -78,10 +78,76 @@
 #include <thread>
 #include <tuple>
 
+#if defined(CONF_FAMILY_WINDOWS)
+#include <windows.h>
+#include <dbghelp.h>
+#ifdef ERROR
+#undef ERROR
+#endif
+#endif
+
 using namespace std::chrono_literals;
 
 static constexpr ColorRGBA gs_ClientNetworkPrintColor{0.7f, 1, 0.7f, 1.0f};
 static constexpr ColorRGBA gs_ClientNetworkErrPrintColor{1.0f, 0.25f, 0.25f, 1.0f};
+static constexpr int64_t gs_HangTimeoutSeconds = 10;
+
+static const char *ClientStateToString(int State)
+{
+	switch(State)
+	{
+	case IClient::STATE_OFFLINE:
+		return "offline";
+	case IClient::STATE_CONNECTING:
+		return "connecting";
+	case IClient::STATE_LOADING:
+		return "loading";
+	case IClient::STATE_ONLINE:
+		return "online";
+	case IClient::STATE_DEMOPLAYBACK:
+		return "demoplayback";
+	case IClient::STATE_QUITTING:
+		return "quitting";
+	case IClient::STATE_RESTARTING:
+		return "restarting";
+	default:
+		return "unknown";
+	}
+}
+
+#if defined(CONF_FAMILY_WINDOWS)
+static bool WriteMiniDumpFile(const char *pFilename)
+{
+	using MiniDumpWriteDumpFunc = BOOL(WINAPI *)(HANDLE, DWORD, HANDLE, MINIDUMP_TYPE,
+		const MINIDUMP_EXCEPTION_INFORMATION *, const MINIDUMP_USER_STREAM_INFORMATION *, const MINIDUMP_CALLBACK_INFORMATION *);
+
+	HMODULE pDbgHelp = LoadLibraryA("dbghelp.dll");
+	if(pDbgHelp == nullptr)
+		return false;
+
+	auto pMiniDumpWriteDump = (MiniDumpWriteDumpFunc)GetProcAddress(pDbgHelp, "MiniDumpWriteDump");
+	if(pMiniDumpWriteDump == nullptr)
+	{
+		FreeLibrary(pDbgHelp);
+		return false;
+	}
+
+	HANDLE FileHandle = CreateFileA(pFilename, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+	if(FileHandle == INVALID_HANDLE_VALUE)
+	{
+		FreeLibrary(pDbgHelp);
+		return false;
+	}
+
+	const MINIDUMP_TYPE DumpType = static_cast<MINIDUMP_TYPE>(
+		MiniDumpWithDataSegs | MiniDumpWithHandleData | MiniDumpWithIndirectlyReferencedMemory);
+	const BOOL Result = pMiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(), FileHandle, DumpType, nullptr, nullptr, nullptr);
+
+	CloseHandle(FileHandle);
+	FreeLibrary(pDbgHelp);
+	return Result != FALSE;
+}
+#endif
 
 CClient::CClient() :
 	m_DemoPlayer(&m_SnapshotDelta, true, [&]() { UpdateDemoIntraTimers(); }),
@@ -3135,6 +3201,16 @@ void CClient::Run()
 	m_aSnapshotParts[0] = 0;
 	m_aSnapshotParts[1] = 0;
 
+	StartHangWatchdog();
+	struct CHangWatchdogGuard
+	{
+		CClient *m_pClient;
+		~CHangWatchdogGuard()
+		{
+			m_pClient->StopHangWatchdog();
+		}
+	} HangWatchdogGuard{this};
+
 	if(m_GenerateTimeoutSeed)
 	{
 		GenerateTimeoutSeed();
@@ -3271,6 +3347,7 @@ void CClient::Run()
 	while(true)
 	{
 		set_new_tick();
+		UpdateHangHeartbeat();
 
 		// handle pending connects
 		if(m_aCmdConnect[0])
@@ -3471,6 +3548,8 @@ void CClient::Run()
 		m_LocalTime = (time_get() - m_LocalStartTime) / (float)time_freq();
 		m_GlobalTime = (time_get() - m_GlobalStartTime) / (float)time_freq();
 	}
+
+	StopHangWatchdog();
 
 	GameClient()->RenderShutdownMessage();
 	Disconnect();
@@ -4260,6 +4339,121 @@ void CClient::BenchmarkQuit(int Seconds, const char *pFilename)
 {
 	m_BenchmarkFile = Storage()->OpenFile(pFilename, IOFLAG_WRITE, IStorage::TYPE_ABSOLUTE);
 	m_BenchmarkStopTime = time_get() + time_freq() * Seconds;
+}
+
+void CClient::StartHangWatchdog()
+{
+	m_HangWatchdogStop.store(false, std::memory_order_release);
+	m_HangReportWritten.store(false, std::memory_order_release);
+	if(m_aHangDumpDir[0] == '\0' && Storage() != nullptr)
+		Storage()->GetCompletePath(IStorage::TYPE_SAVE, "dumps", m_aHangDumpDir, sizeof(m_aHangDumpDir));
+	UpdateHangHeartbeat();
+
+	if(m_HangWatchdogThread.joinable())
+		return;
+
+	m_HangWatchdogThread = std::thread([this]() {
+		const int64_t TimeoutTicks = time_freq() * gs_HangTimeoutSeconds;
+		while(!m_HangWatchdogStop.load(std::memory_order_acquire))
+		{
+			std::this_thread::sleep_for(1s);
+			const int64_t LastHeartbeat = m_HangLastHeartbeat.load(std::memory_order_acquire);
+			if(LastHeartbeat == 0)
+				continue;
+			const int64_t Now = time_get();
+			if(Now - LastHeartbeat >= TimeoutTicks)
+			{
+				if(!m_HangReportWritten.exchange(true, std::memory_order_acq_rel))
+					WriteHangReportAndDump(Now, LastHeartbeat);
+			}
+		}
+	});
+}
+
+void CClient::StopHangWatchdog()
+{
+	m_HangWatchdogStop.store(true, std::memory_order_release);
+	if(m_HangWatchdogThread.joinable())
+		m_HangWatchdogThread.join();
+}
+
+void CClient::UpdateHangHeartbeat()
+{
+	const int NextIndex = 1 - m_HangInfoIndex.load(std::memory_order_relaxed);
+	SHangInfo &Info = m_aHangInfo[NextIndex];
+	Info.m_State = m_State;
+	str_copy(Info.m_aCurrentMap, m_aCurrentMap, sizeof(Info.m_aCurrentMap));
+	const NETADDR &Addr = ServerAddress();
+	if(Addr.type == NETTYPE_INVALID)
+	{
+		str_copy(Info.m_aServerAddr, "unknown", sizeof(Info.m_aServerAddr));
+	}
+	else
+	{
+		char aAddr[NETADDR_MAXSTRSIZE];
+		net_addr_str(&Addr, aAddr, sizeof(aAddr), true);
+		str_copy(Info.m_aServerAddr, aAddr, sizeof(Info.m_aServerAddr));
+	}
+	m_HangInfoIndex.store(NextIndex, std::memory_order_release);
+	m_HangLastHeartbeat.store(time_get(), std::memory_order_release);
+}
+
+void CClient::WriteHangReportAndDump(int64_t Now, int64_t LastHeartbeat)
+{
+	if(m_aHangDumpDir[0] == '\0')
+		return;
+
+	char aDate[64];
+	str_timestamp(aDate, sizeof(aDate));
+
+	char aReportFilename[IO_MAX_PATH_LENGTH];
+	str_format(aReportFilename, sizeof(aReportFilename),
+		GAME_NAME "_%s_hang_report_%s_%d_%s.txt",
+		CONF_PLATFORM_STRING, aDate, pid(), GIT_SHORTREV_HASH != nullptr ? GIT_SHORTREV_HASH : "");
+	char aReportPath[IO_MAX_PATH_LENGTH];
+	str_format(aReportPath, sizeof(aReportPath), "%s/%s", m_aHangDumpDir, aReportFilename);
+	fs_makedir_rec_for(aReportPath);
+
+	IOHANDLE File = io_open(aReportPath, IOFLAG_WRITE);
+	if(File)
+	{
+		const int SnapshotIndex = m_HangInfoIndex.load(std::memory_order_acquire);
+		const SHangInfo Snapshot = m_aHangInfo[SnapshotIndex];
+		const float SecondsSinceHeartbeat = (Now - LastHeartbeat) / (float)time_freq();
+
+		char aBuf[1024];
+		str_format(aBuf, sizeof(aBuf), "Hang detected (no main thread heartbeat for %.1f seconds)\n", SecondsSinceHeartbeat);
+		io_write(File, aBuf, str_length(aBuf));
+
+		str_format(aBuf, sizeof(aBuf), "Timestamp: %s\n", aDate);
+		io_write(File, aBuf, str_length(aBuf));
+
+		str_format(aBuf, sizeof(aBuf), "Client state: %s (%d)\n", ClientStateToString(Snapshot.m_State), Snapshot.m_State);
+		io_write(File, aBuf, str_length(aBuf));
+
+		str_format(aBuf, sizeof(aBuf), "Current map: %s\n", Snapshot.m_aCurrentMap);
+		io_write(File, aBuf, str_length(aBuf));
+
+		str_format(aBuf, sizeof(aBuf), "Server address: %s\n", Snapshot.m_aServerAddr);
+		io_write(File, aBuf, str_length(aBuf));
+
+		str_format(aBuf, sizeof(aBuf), "Game version: %s %s %s\n", GAME_NAME, GAME_RELEASE_VERSION, GIT_SHORTREV_HASH != nullptr ? GIT_SHORTREV_HASH : "");
+		io_write(File, aBuf, str_length(aBuf));
+
+		io_sync(File);
+		io_close(File);
+	}
+
+#if defined(CONF_FAMILY_WINDOWS)
+	char aDumpFilename[IO_MAX_PATH_LENGTH];
+	str_format(aDumpFilename, sizeof(aDumpFilename),
+		GAME_NAME "_%s_hang_dump_%s_%d_%s.dmp",
+		CONF_PLATFORM_STRING, aDate, pid(), GIT_SHORTREV_HASH != nullptr ? GIT_SHORTREV_HASH : "");
+	char aDumpPath[IO_MAX_PATH_LENGTH];
+	str_format(aDumpPath, sizeof(aDumpPath), "%s/%s", m_aHangDumpDir, aDumpFilename);
+	fs_makedir_rec_for(aDumpPath);
+	WriteMiniDumpFile(aDumpPath);
+#endif
 }
 
 void CClient::UpdateAndSwap()

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -25,10 +25,12 @@
 #include <engine/textrender.h>
 #include <engine/warning.h>
 
+#include <atomic>
 #include <chrono>
 #include <deque>
 #include <memory>
 #include <mutex>
+#include <thread>
 
 class CDemoEdit;
 class IDemoRecorder;
@@ -101,6 +103,21 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	uint64_t m_aSnapshotParts[NUM_DUMMIES] = {0, 0};
 	int64_t m_LocalStartTime = 0;
 	int64_t m_GlobalStartTime = 0;
+
+	struct SHangInfo
+	{
+		int m_State = IClient::STATE_OFFLINE;
+		char m_aCurrentMap[IO_MAX_PATH_LENGTH] = "";
+		char m_aServerAddr[NETADDR_MAXSTRSIZE] = "";
+	};
+
+	std::atomic<int64_t> m_HangLastHeartbeat{0};
+	std::atomic<bool> m_HangWatchdogStop{false};
+	std::atomic<bool> m_HangReportWritten{false};
+	std::atomic<int> m_HangInfoIndex{0};
+	SHangInfo m_aHangInfo[2];
+	std::thread m_HangWatchdogThread;
+	char m_aHangDumpDir[IO_MAX_PATH_LENGTH] = "";
 
 	IGraphics::CTextureHandle m_DebugFont;
 
@@ -264,6 +281,10 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	void UpdateDemoIntraTimers();
 	int MaxLatencyTicks() const;
 	int PredictionMargin() const;
+	void StartHangWatchdog();
+	void StopHangWatchdog();
+	void UpdateHangHeartbeat();
+	void WriteHangReportAndDump(int64_t Now, int64_t LastHeartbeat);
 
 	std::shared_ptr<ILogger> m_pFileLogger = nullptr;
 	std::shared_ptr<ILogger> m_pStdoutLogger = nullptr;

--- a/src/engine/client/friends.cpp
+++ b/src/engine/client/friends.cpp
@@ -102,6 +102,18 @@ void CFriends::ConSetFriendCategory(IConsole::IResult *pResult, void *pUserData)
 	pSelf->SetFriendCategory(pResult->GetString(0), pResult->GetString(1), pResult->GetString(2));
 }
 
+void CFriends::ConSetFriendNote(IConsole::IResult *pResult, void *pUserData)
+{
+	CFriends *pSelf = (CFriends *)pUserData;
+	pSelf->SetFriendNote(pResult->GetString(0), pResult->GetString(1), pResult->GetString(2));
+}
+
+void CFriends::ConClearFriendNote(IConsole::IResult *pResult, void *pUserData)
+{
+	CFriends *pSelf = (CFriends *)pUserData;
+	pSelf->ClearFriendNote(pResult->GetString(0), pResult->GetString(1));
+}
+
 void CFriends::ConFriends(IConsole::IResult *pResult, void *pUserData)
 {
 	CFriends *pSelf = (CFriends *)pUserData;
@@ -134,6 +146,8 @@ void CFriends::Init(bool Foes)
 	pConsole->Register("friend_category_rename", "s[old_category] s[new_category]", CFGFLAG_CLIENT, ConRenameFriendCategory, this, "Rename a friend category");
 	pConsole->Register("friend_category_remove", "s[category]", CFGFLAG_CLIENT, ConRemoveFriendCategory, this, "Remove a friend category");
 	pConsole->Register("set_friend_category", "s[name] s[clan] s[category]", CFGFLAG_CLIENT, ConSetFriendCategory, this, "Set friend category");
+	pConsole->Register("set_friend_note", "s[name] s[clan] r[note]", CFGFLAG_CLIENT, ConSetFriendNote, this, "Set friend note");
+	pConsole->Register("clear_friend_note", "s[name] s[clan]", CFGFLAG_CLIENT, ConClearFriendNote, this, "Clear friend note");
 	pConsole->Register("friends", "", CFGFLAG_CLIENT, ConFriends, this, "List friends");
 }
 
@@ -195,6 +209,44 @@ const char *CFriends::GetFriendCategory(const char *pName, const char *pClan) co
 		}
 	}
 	return IFriends::OFFLINE_CATEGORY;
+}
+
+const char *CFriends::GetFriendNote(const char *pName, const char *pClan) const
+{
+	const int FriendIndex = FindFriend(pName, pClan);
+	if(FriendIndex < 0)
+		return "";
+
+	return m_aFriends[FriendIndex].m_aNote;
+}
+
+bool CFriends::SetFriendNote(const char *pName, const char *pClan, const char *pNote)
+{
+	const int FriendIndex = FindFriend(pName, pClan);
+	if(FriendIndex < 0 || m_aFriends[FriendIndex].m_aName[0] == '\0')
+		return false;
+
+	char aNote[IFriends::MAX_FRIEND_NOTE_LENGTH];
+	if(pNote == nullptr)
+	{
+		aNote[0] = '\0';
+	}
+	else
+	{
+		str_copy(aNote, pNote, sizeof(aNote));
+		str_utf8_trim_right(aNote);
+	}
+
+	if(str_comp(m_aFriends[FriendIndex].m_aNote, aNote) == 0)
+		return false;
+
+	str_copy(m_aFriends[FriendIndex].m_aNote, aNote, sizeof(m_aFriends[FriendIndex].m_aNote));
+	return true;
+}
+
+bool CFriends::ClearFriendNote(const char *pName, const char *pClan)
+{
+	return SetFriendNote(pName, pClan, "");
 }
 
 const char *CFriends::GetCategory(int Index) const
@@ -351,6 +403,7 @@ void CFriends::AddFriend(const char *pName, const char *pClan, const char *pCate
 	str_copy(m_aFriends[m_NumFriends].m_aName, pName, sizeof(m_aFriends[m_NumFriends].m_aName));
 	str_copy(m_aFriends[m_NumFriends].m_aClan, pClan, sizeof(m_aFriends[m_NumFriends].m_aClan));
 	str_copy(m_aFriends[m_NumFriends].m_aCategory, aCategory, sizeof(m_aFriends[m_NumFriends].m_aCategory));
+	m_aFriends[m_NumFriends].m_aNote[0] = '\0';
 	m_aFriends[m_NumFriends].m_NameHash = NameHash;
 	m_aFriends[m_NumFriends].m_ClanHash = ClanHash;
 	++m_NumFriends;
@@ -433,5 +486,20 @@ void CFriends::ConfigSaveCallback(IConfigManager *pConfigManager, void *pUserDat
 		}
 
 		pConfigManager->WriteLine(aBuf);
+
+		if(!pSelf->m_Foes && pSelf->m_aFriends[i].m_aNote[0] != '\0')
+		{
+			str_copy(aBuf, "set_friend_note \"");
+			char *pNoteDst = aBuf + str_length(aBuf);
+			str_escape(&pNoteDst, pSelf->m_aFriends[i].m_aName, pEnd);
+			str_append(aBuf, "\" \"");
+			pNoteDst = aBuf + str_length(aBuf);
+			str_escape(&pNoteDst, pSelf->m_aFriends[i].m_aClan, pEnd);
+			str_append(aBuf, "\" \"");
+			pNoteDst = aBuf + str_length(aBuf);
+			str_escape(&pNoteDst, pSelf->m_aFriends[i].m_aNote, pEnd);
+			str_append(aBuf, "\"");
+			pConfigManager->WriteLine(aBuf);
+		}
 	}
 }

--- a/src/engine/client/friends.h
+++ b/src/engine/client/friends.h
@@ -22,6 +22,8 @@ class CFriends : public IFriends
 	static void ConRenameFriendCategory(IConsole::IResult *pResult, void *pUserData);
 	static void ConRemoveFriendCategory(IConsole::IResult *pResult, void *pUserData);
 	static void ConSetFriendCategory(IConsole::IResult *pResult, void *pUserData);
+	static void ConSetFriendNote(IConsole::IResult *pResult, void *pUserData);
+	static void ConClearFriendNote(IConsole::IResult *pResult, void *pUserData);
 	static void ConFriends(IConsole::IResult *pResult, void *pUserData);
 
 	static void ConfigSaveCallback(IConfigManager *pConfigManager, void *pUserData);
@@ -41,6 +43,9 @@ public:
 	int GetFriendState(const char *pName, const char *pClan) const override;
 	bool IsFriend(const char *pName, const char *pClan, bool PlayersOnly) const override;
 	const char *GetFriendCategory(const char *pName, const char *pClan) const override;
+	const char *GetFriendNote(const char *pName, const char *pClan) const override;
+	bool SetFriendNote(const char *pName, const char *pClan, const char *pNote) override;
+	bool ClearFriendNote(const char *pName, const char *pClan) override;
 
 	const char *DefaultCategory() const override { return IFriends::DEFAULT_CATEGORY; }
 	int NumCategories() const override { return m_NumCategories; }

--- a/src/engine/friends.h
+++ b/src/engine/friends.h
@@ -12,6 +12,7 @@ struct CFriendInfo
 	char m_aName[MAX_NAME_LENGTH];
 	char m_aClan[MAX_CLAN_LENGTH];
 	char m_aCategory[64];
+	char m_aNote[128];
 	unsigned m_NameHash;
 	unsigned m_ClanHash;
 };
@@ -29,6 +30,7 @@ public:
 	static constexpr auto MAX_FRIENDS = 4096;
 	static constexpr int MAX_FRIEND_CATEGORIES = 64;
 	static constexpr int MAX_FRIEND_CATEGORY_LENGTH = 64;
+	static constexpr int MAX_FRIEND_NOTE_LENGTH = 128;
 	static constexpr const char *DEFAULT_CATEGORY = "好友";
 	static constexpr const char *CLAN_MEMBERS_CATEGORY = "战队成员";
 	static constexpr const char *OFFLINE_CATEGORY = "离线";
@@ -40,6 +42,9 @@ public:
 	virtual int GetFriendState(const char *pName, const char *pClan) const = 0;
 	virtual bool IsFriend(const char *pName, const char *pClan, bool PlayersOnly) const = 0;
 	virtual const char *GetFriendCategory(const char *pName, const char *pClan) const = 0;
+	virtual const char *GetFriendNote(const char *pName, const char *pClan) const = 0;
+	virtual bool SetFriendNote(const char *pName, const char *pClan, const char *pNote) = 0;
+	virtual bool ClearFriendNote(const char *pName, const char *pClan) = 0;
 
 	virtual const char *DefaultCategory() const = 0;
 	virtual int NumCategories() const = 0;

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -358,6 +358,7 @@ MACRO_CONFIG_INT(ClPrintMotd, cl_print_motd, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_S
 MACRO_CONFIG_INT(ClFriendsIgnoreClan, cl_friends_ignore_clan, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "搜索好友时忽略战队标签")
 MACRO_CONFIG_COL(ClFriendsListFriendColor, cl_friends_list_friend_color, 0x20D9A8, CFGFLAG_CLIENT | CFGFLAG_SAVE, "好友列表中好友条目颜色")
 MACRO_CONFIG_COL(ClFriendsListClanColor, cl_friends_list_clan_color, 0xB1B48C, CFGFLAG_CLIENT | CFGFLAG_SAVE, "好友列表中战队成员条目颜色")
+MACRO_CONFIG_STR(ClFriendsCategoryExpanded, cl_friends_category_expanded, 128, "", CFGFLAG_CLIENT | CFGFLAG_SAVE, "好友栏分类展开状态(1=展开,0=收起)")
 
 MACRO_CONFIG_STR(ClAssetsEntities, cl_assets_entities, 50, "default", CFGFLAG_SAVE | CFGFLAG_CLIENT, "The asset/assets for entities")
 MACRO_CONFIG_STR(ClAssetGame, cl_asset_game, 50, "default", CFGFLAG_SAVE | CFGFLAG_CLIENT, "The asset for game")

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -28,6 +28,7 @@
 #include <chrono>
 #include <deque>
 #include <optional>
+#include <string>
 #include <vector>
 
 class CMenus : public CComponent
@@ -446,6 +447,10 @@ protected:
 	};
 
 	std::vector<unsigned char> m_vFriendsCategoryExpanded;
+	std::vector<std::string> m_vFriendsCategoryNames;
+	std::string m_FriendsCategoryExpandedStateCache;
+	bool m_FriendsCategoryExpandedLoaded = false;
+	std::vector<std::string> m_vFriendTooltipText;
 	int m_FriendAddCategoryIndex = 0;
 	CUi::SDropDownState m_FriendsAddCategoryDropDownState;
 	class CFriendsCategoryPopupContext : public SPopupMenuId
@@ -472,6 +477,29 @@ protected:
 	bool m_HasMoveCategoryFriend = false;
 	char m_aMoveCategoryFriendName[MAX_NAME_LENGTH] = {0};
 	char m_aMoveCategoryFriendClan[MAX_CLAN_LENGTH] = {0};
+	enum EFriendAction
+	{
+		FRIEND_ACTION_MOVE_CATEGORY = 0,
+		FRIEND_ACTION_EDIT_NOTE,
+		FRIEND_ACTION_CLEAR_NOTE,
+		FRIEND_ACTION_REMOVE,
+	};
+	CUi::SSelectionPopupContext m_FriendsActionPopupContext;
+	std::vector<EFriendAction> m_vFriendsActionEntries;
+	bool m_HasFriendAction = false;
+	char m_aFriendActionName[MAX_NAME_LENGTH] = {0};
+	char m_aFriendActionClan[MAX_CLAN_LENGTH] = {0};
+	int m_FriendActionState = IFriends::FRIEND_NO;
+	class CFriendNotePopupContext : public SPopupMenuId
+	{
+	public:
+		CMenus *m_pMenus = nullptr;
+		char m_aName[MAX_NAME_LENGTH] = {0};
+		char m_aClan[MAX_CLAN_LENGTH] = {0};
+		CLineInputBuffered<IFriends::MAX_FRIEND_NOTE_LENGTH> m_NoteInput;
+		CButtonContainer m_ConfirmButton;
+		CButtonContainer m_CancelButton;
+	} m_FriendNotePopupContext;
 	bool m_HasRemoveFriend = false;
 	char m_aRemoveFriendName[MAX_NAME_LENGTH] = {0};
 	char m_aRemoveFriendClan[MAX_CLAN_LENGTH] = {0};
@@ -568,7 +596,11 @@ protected:
 	void RenderServerbrowserInfoScoreboard(CUIRect View, const CServerInfo *pSelectedServer);
 	void RenderServerbrowserFriends(CUIRect View);
 	static CUi::EPopupMenuFunctionResult PopupFriendsCategory(void *pContext, CUIRect View, bool Active);
+	static CUi::EPopupMenuFunctionResult PopupFriendNote(void *pContext, CUIRect View, bool Active);
 	void FriendlistOnUpdate();
+	void ApplyFriendsCategoryExpandedState();
+	void SaveFriendsCategoryExpandedState();
+	void RefreshFriendsCategoryNames();
 	void PopupConfirmRemoveFriend();
 	void PopupCancelRemoveFriend();
 	void RenderServerbrowserTabBar(CUIRect TabBar);

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -685,6 +685,7 @@ void CMenus::RenderServerbrowserStatusBox(CUIRect StatusBox, bool WasListboxItem
 
 			SMenuButtonProperties Props;
 			Props.m_HintRequiresStringCheck = true;
+			Props.m_HintCanChangePositionOrSize = true;
 			Props.m_UseIconFont = true;
 
 			static CButtonContainer s_RefreshButton;
@@ -700,6 +701,7 @@ void CMenus::RenderServerbrowserStatusBox(CUIRect StatusBox, bool WasListboxItem
 
 			SMenuButtonProperties Props;
 			Props.m_UseIconFont = true;
+			Props.m_HintCanChangePositionOrSize = true;
 			Props.m_Color = ColorRGBA(0.5f, 1.0f, 0.5f, 0.5f);
 
 			static CButtonContainer s_ConnectButton;
@@ -1475,6 +1477,7 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 	// calculate friends
 	bool OpenRemovePopup = false;
 	static CScrollRegion s_FriendsMoveCategoryPopupScrollRegion;
+	static CScrollRegion s_FriendsActionPopupScrollRegion;
 	for(int FriendIndex = 0; FriendIndex < GameClient()->Friends()->NumFriends(); ++FriendIndex)
 	{
 		const CFriendInfo *pFriendInfo = GameClient()->Friends()->GetFriend(FriendIndex);
@@ -1527,6 +1530,12 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 		});
 	}
 
+	int TotalFriendItems = 0;
+	for(const auto &vFriends : vvFriends)
+		TotalFriendItems += (int)vFriends.size();
+	m_vFriendTooltipText.clear();
+	m_vFriendTooltipText.resize(TotalFriendItems);
+
 	// friends list
 	static CScrollRegion s_ScrollRegion;
 	vec2 ScrollOffset(0.0f, 0.0f);
@@ -1539,6 +1548,7 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 	List.y += ScrollOffset.y;
 
 	char aBuf[256];
+	int FriendTooltipIndex = 0;
 	for(int CategoryIndex = 0; CategoryIndex < NumCategories; ++CategoryIndex)
 	{
 		// header
@@ -1576,6 +1586,7 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 		else if(HeaderResult == 1)
 		{
 			m_vFriendsCategoryExpanded[CategoryIndex] = !m_vFriendsCategoryExpanded[CategoryIndex];
+			SaveFriendsCategoryExpandedState();
 		}
 
 		// entries
@@ -1592,6 +1603,9 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 
 				CUIRect Rect;
 				const auto &Friend = vvFriends[CategoryIndex][FriendIndex];
+				const bool IsPlayerFriend = Friend.FriendState() == IFriends::FRIEND_PLAYER;
+				const char *pNote = IsPlayerFriend ? GameClient()->Friends()->GetFriendNote(Friend.Name(), Friend.Clan()) : "";
+				const bool HasNote = pNote[0] != '\0';
 				const unsigned NameHash = str_quickhash(Friend.Name());
 				const unsigned ClanHash = str_quickhash(Friend.Clan());
 				const unsigned AddrHash = Friend.ServerInfo() != nullptr ? str_quickhash(Friend.ServerInfo()->m_aAddress) : 0;
@@ -1611,10 +1625,28 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 				const bool Inside = Ui()->MouseHovered(&Rect);
 				int ButtonResult = Ui()->DoButtonLogic(pListItemId, 0, &Rect, BUTTONFLAG_LEFT | BUTTONFLAG_RIGHT);
 
-				if(Friend.ServerInfo())
+				if(Friend.ServerInfo() || HasNote)
 				{
-					GameClient()->m_Tooltips.DoToolTip(pListItemId, &Rect, Localize("Click to select server. Double click to join your friend."));
+					std::string &TooltipText = m_vFriendTooltipText[FriendTooltipIndex];
+					TooltipText.clear();
+					if(Friend.ServerInfo() && HasNote)
+					{
+						TooltipText = Localize("Click to select server. Double click to join your friend.");
+						TooltipText.append("\n备注: ");
+						TooltipText.append(pNote);
+					}
+					else if(Friend.ServerInfo())
+					{
+						TooltipText = Localize("Click to select server. Double click to join your friend.");
+					}
+					else
+					{
+						TooltipText = "备注: ";
+						TooltipText.append(pNote);
+					}
+					GameClient()->m_Tooltips.DoToolTip(pListItemId, &Rect, TooltipText.c_str());
 				}
+				++FriendTooltipIndex;
 				const bool IsOffline = Friend.ServerInfo() == nullptr;
 				const ColorRGBA Color = PlayerBackgroundColor(Friend.FriendState() == IFriends::FRIEND_PLAYER, Friend.FriendState() == IFriends::FRIEND_CLAN, IsOffline ? true : Friend.IsAfk(), Inside);
 				Rect.Draw(Color, IGraphics::CORNER_ALL, 5.0f);
@@ -1722,30 +1754,43 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 				if(ButtonResult == 2)
 				{
 					const bool CanMoveCategory = Friend.FriendState() == IFriends::FRIEND_PLAYER && !IsClanMembersCategory(Friend.Category());
+					const bool CanEditNote = Friend.FriendState() == IFriends::FRIEND_PLAYER;
+
+					m_FriendsActionPopupContext.Reset();
+					m_FriendsActionPopupContext.m_pScrollRegion = &s_FriendsActionPopupScrollRegion;
+					m_vFriendsActionEntries.clear();
+					m_FriendsActionPopupContext.m_EntryHeight = 18.0f;
+					m_FriendsActionPopupContext.m_EntryPadding = 1.0f;
+					m_FriendsActionPopupContext.m_FontSize = (m_FriendsActionPopupContext.m_EntryHeight - 2 * m_FriendsActionPopupContext.m_EntryPadding) * CUi::ms_FontmodHeight;
+					m_FriendsActionPopupContext.m_Width = 180.0f;
+
 					if(CanMoveCategory)
 					{
-						m_FriendsMoveCategoryPopupContext.Reset();
-						m_FriendsMoveCategoryPopupContext.m_pScrollRegion = &s_FriendsMoveCategoryPopupScrollRegion;
-						str_copy(m_FriendsMoveCategoryPopupContext.m_aMessage, "移动到分类");
-						m_FriendsMoveCategoryPopupContext.m_EntryHeight = 18.0f;
-						m_FriendsMoveCategoryPopupContext.m_EntryPadding = 1.0f;
-						m_FriendsMoveCategoryPopupContext.m_FontSize = (m_FriendsMoveCategoryPopupContext.m_EntryHeight - 2 * m_FriendsMoveCategoryPopupContext.m_EntryPadding) * CUi::ms_FontmodHeight;
-						m_FriendsMoveCategoryPopupContext.m_Width = 180.0f;
-						for(int MoveCategoryIndex = 0; MoveCategoryIndex < NumCategories; ++MoveCategoryIndex)
-						{
-							const char *pMoveCategory = GameClient()->Friends()->GetCategory(MoveCategoryIndex);
-							if(IsClanMembersCategory(pMoveCategory))
-								continue;
-							m_FriendsMoveCategoryPopupContext.m_vEntries.emplace_back(pMoveCategory);
-						}
+						m_FriendsActionPopupContext.m_vEntries.emplace_back("移动到分类");
+						m_vFriendsActionEntries.push_back(FRIEND_ACTION_MOVE_CATEGORY);
+					}
 
-						if(!m_FriendsMoveCategoryPopupContext.m_vEntries.empty())
+					if(CanEditNote)
+					{
+						m_FriendsActionPopupContext.m_vEntries.emplace_back("编辑备注");
+						m_vFriendsActionEntries.push_back(FRIEND_ACTION_EDIT_NOTE);
+						if(HasNote)
 						{
-							str_copy(m_aMoveCategoryFriendName, Friend.Name(), sizeof(m_aMoveCategoryFriendName));
-							str_copy(m_aMoveCategoryFriendClan, Friend.Clan(), sizeof(m_aMoveCategoryFriendClan));
-							m_HasMoveCategoryFriend = true;
-							Ui()->ShowPopupSelection(Ui()->MouseX(), Ui()->MouseY(), &m_FriendsMoveCategoryPopupContext);
+							m_FriendsActionPopupContext.m_vEntries.emplace_back("清除备注");
+							m_vFriendsActionEntries.push_back(FRIEND_ACTION_CLEAR_NOTE);
 						}
+					}
+
+					m_FriendsActionPopupContext.m_vEntries.emplace_back("移除好友");
+					m_vFriendsActionEntries.push_back(FRIEND_ACTION_REMOVE);
+
+					if(!m_FriendsActionPopupContext.m_vEntries.empty())
+					{
+						str_copy(m_aFriendActionName, Friend.Name(), sizeof(m_aFriendActionName));
+						str_copy(m_aFriendActionClan, Friend.Clan(), sizeof(m_aFriendActionClan));
+						m_FriendActionState = Friend.FriendState();
+						m_HasFriendAction = true;
+						Ui()->ShowPopupSelection(Ui()->MouseX(), Ui()->MouseY(), &m_FriendsActionPopupContext);
 					}
 
 					ButtonResult = 0;
@@ -1787,6 +1832,77 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 	}
 
 	s_ScrollRegion.End();
+
+	if(m_HasFriendAction && m_FriendsActionPopupContext.m_pSelection != nullptr)
+	{
+		const int SelectionIndex = m_FriendsActionPopupContext.m_SelectionIndex;
+		if(SelectionIndex >= 0 && SelectionIndex < (int)m_vFriendsActionEntries.size())
+		{
+			const EFriendAction Action = m_vFriendsActionEntries[SelectionIndex];
+			if(Action == FRIEND_ACTION_MOVE_CATEGORY)
+			{
+				m_FriendsMoveCategoryPopupContext.Reset();
+				m_FriendsMoveCategoryPopupContext.m_pScrollRegion = &s_FriendsMoveCategoryPopupScrollRegion;
+				str_copy(m_FriendsMoveCategoryPopupContext.m_aMessage, "移动到分类");
+				m_FriendsMoveCategoryPopupContext.m_EntryHeight = 18.0f;
+				m_FriendsMoveCategoryPopupContext.m_EntryPadding = 1.0f;
+				m_FriendsMoveCategoryPopupContext.m_FontSize = (m_FriendsMoveCategoryPopupContext.m_EntryHeight - 2 * m_FriendsMoveCategoryPopupContext.m_EntryPadding) * CUi::ms_FontmodHeight;
+				m_FriendsMoveCategoryPopupContext.m_Width = 180.0f;
+				for(int MoveCategoryIndex = 0; MoveCategoryIndex < NumCategories; ++MoveCategoryIndex)
+				{
+					const char *pMoveCategory = GameClient()->Friends()->GetCategory(MoveCategoryIndex);
+					if(IsClanMembersCategory(pMoveCategory))
+						continue;
+					m_FriendsMoveCategoryPopupContext.m_vEntries.emplace_back(pMoveCategory);
+				}
+
+				if(!m_FriendsMoveCategoryPopupContext.m_vEntries.empty())
+				{
+					str_copy(m_aMoveCategoryFriendName, m_aFriendActionName, sizeof(m_aMoveCategoryFriendName));
+					str_copy(m_aMoveCategoryFriendClan, m_aFriendActionClan, sizeof(m_aMoveCategoryFriendClan));
+					m_HasMoveCategoryFriend = true;
+					Ui()->ShowPopupSelection(Ui()->MouseX(), Ui()->MouseY(), &m_FriendsMoveCategoryPopupContext);
+				}
+			}
+			else if(Action == FRIEND_ACTION_EDIT_NOTE)
+			{
+				m_FriendNotePopupContext.m_pMenus = this;
+				str_copy(m_FriendNotePopupContext.m_aName, m_aFriendActionName, sizeof(m_FriendNotePopupContext.m_aName));
+				str_copy(m_FriendNotePopupContext.m_aClan, m_aFriendActionClan, sizeof(m_FriendNotePopupContext.m_aClan));
+				m_FriendNotePopupContext.m_NoteInput.Set(GameClient()->Friends()->GetFriendNote(m_aFriendActionName, m_aFriendActionClan));
+				m_FriendNotePopupContext.m_NoteInput.SelectAll();
+				Ui()->DoPopupMenu(&m_FriendNotePopupContext, Ui()->MouseX(), Ui()->MouseY(), 320.0f, 70.0f, &m_FriendNotePopupContext, PopupFriendNote);
+			}
+			else if(Action == FRIEND_ACTION_CLEAR_NOTE)
+			{
+				GameClient()->Friends()->ClearFriendNote(m_aFriendActionName, m_aFriendActionClan);
+			}
+			else if(Action == FRIEND_ACTION_REMOVE)
+			{
+				str_copy(m_aRemoveFriendName, m_aFriendActionName, sizeof(m_aRemoveFriendName));
+				str_copy(m_aRemoveFriendClan, m_aFriendActionClan, sizeof(m_aRemoveFriendClan));
+				m_RemoveFriendState = m_FriendActionState;
+				m_HasRemoveFriend = true;
+				OpenRemovePopup = true;
+			}
+		}
+
+		m_FriendsActionPopupContext.Reset();
+		m_vFriendsActionEntries.clear();
+		m_HasFriendAction = false;
+		m_aFriendActionName[0] = '\0';
+		m_aFriendActionClan[0] = '\0';
+		m_FriendActionState = IFriends::FRIEND_NO;
+	}
+	else if(m_HasFriendAction && !Ui()->IsPopupOpen(&m_FriendsActionPopupContext))
+	{
+		m_FriendsActionPopupContext.Reset();
+		m_vFriendsActionEntries.clear();
+		m_HasFriendAction = false;
+		m_aFriendActionName[0] = '\0';
+		m_aFriendActionClan[0] = '\0';
+		m_FriendActionState = IFriends::FRIEND_NO;
+	}
 
 	if(m_HasMoveCategoryFriend && m_FriendsMoveCategoryPopupContext.m_pSelection != nullptr)
 	{
@@ -2007,13 +2123,163 @@ CUi::EPopupMenuFunctionResult CMenus::PopupFriendsCategory(void *pContext, CUIRe
 	return CUi::POPUP_KEEP_OPEN;
 }
 
+CUi::EPopupMenuFunctionResult CMenus::PopupFriendNote(void *pContext, CUIRect View, bool Active)
+{
+	CFriendNotePopupContext *pPopupContext = static_cast<CFriendNotePopupContext *>(pContext);
+	CMenus *pMenus = pPopupContext->m_pMenus;
+	if(pMenus == nullptr)
+		return CUi::POPUP_CLOSE_CURRENT;
+
+	const float FontSize = 10.0f;
+	View.Margin(5.0f, &View);
+
+	CUIRect Label, Input, Buttons, Cancel, Confirm;
+	View.HSplitTop(12.0f, &Label, &View);
+	pMenus->Ui()->DoLabel(&Label, "好友备注", FontSize, TEXTALIGN_ML);
+
+	View.HSplitTop(3.0f, nullptr, &View);
+	View.HSplitTop(18.0f, &Input, &View);
+	pMenus->Ui()->DoEditBox(&pPopupContext->m_NoteInput, &Input, FontSize + 1.0f);
+
+	View.HSplitTop(4.0f, nullptr, &View);
+	View.HSplitTop(18.0f, &Buttons, &View);
+	Buttons.VSplitMid(&Cancel, &Confirm, 3.0f);
+
+	const bool CancelPressed = pMenus->Ui()->DoButton_PopupMenu(&pPopupContext->m_CancelButton, "取消", &Cancel, FontSize, TEXTALIGN_MC) || (Active && pMenus->Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE));
+	if(CancelPressed)
+		return CUi::POPUP_CLOSE_CURRENT;
+
+	const bool ConfirmPressed = pMenus->Ui()->DoButton_PopupMenu(&pPopupContext->m_ConfirmButton, "保存", &Confirm, FontSize, TEXTALIGN_MC) || (Active && pMenus->Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER));
+	if(ConfirmPressed)
+	{
+		char aNote[IFriends::MAX_FRIEND_NOTE_LENGTH];
+		str_copy(aNote, pPopupContext->m_NoteInput.GetString(), sizeof(aNote));
+		str_utf8_trim_right(aNote);
+
+		if(aNote[0] == '\0')
+			pMenus->GameClient()->Friends()->ClearFriendNote(pPopupContext->m_aName, pPopupContext->m_aClan);
+		else
+			pMenus->GameClient()->Friends()->SetFriendNote(pPopupContext->m_aName, pPopupContext->m_aClan, aNote);
+		return CUi::POPUP_CLOSE_CURRENT;
+	}
+
+	return CUi::POPUP_KEEP_OPEN;
+}
+
+void CMenus::RefreshFriendsCategoryNames()
+{
+	const int NumCategories = maximum(1, GameClient()->Friends()->NumCategories());
+	m_vFriendsCategoryNames.clear();
+	m_vFriendsCategoryNames.reserve(NumCategories);
+	for(int CategoryIndex = 0; CategoryIndex < NumCategories; ++CategoryIndex)
+		m_vFriendsCategoryNames.emplace_back(GameClient()->Friends()->GetCategory(CategoryIndex));
+}
+
+void CMenus::ApplyFriendsCategoryExpandedState()
+{
+	const int NumCategories = maximum(1, GameClient()->Friends()->NumCategories());
+	m_vFriendsCategoryExpanded.assign(NumCategories, true);
+
+	const char *pState = g_Config.m_ClFriendsCategoryExpanded;
+	const int StateLen = str_length(pState);
+	for(int CategoryIndex = 0; CategoryIndex < NumCategories && CategoryIndex < StateLen; ++CategoryIndex)
+	{
+		if(pState[CategoryIndex] == '0')
+			m_vFriendsCategoryExpanded[CategoryIndex] = false;
+		else if(pState[CategoryIndex] == '1')
+			m_vFriendsCategoryExpanded[CategoryIndex] = true;
+	}
+
+	RefreshFriendsCategoryNames();
+	m_FriendsCategoryExpandedStateCache = g_Config.m_ClFriendsCategoryExpanded;
+	m_FriendsCategoryExpandedLoaded = true;
+}
+
+void CMenus::SaveFriendsCategoryExpandedState()
+{
+	const int NumCategories = maximum(1, GameClient()->Friends()->NumCategories());
+	char aState[sizeof(g_Config.m_ClFriendsCategoryExpanded)];
+	int Pos = 0;
+	for(int CategoryIndex = 0; CategoryIndex < NumCategories && Pos + 1 < (int)sizeof(aState); ++CategoryIndex)
+	{
+		const bool Expanded = CategoryIndex < (int)m_vFriendsCategoryExpanded.size() && m_vFriendsCategoryExpanded[CategoryIndex] != 0;
+		aState[Pos++] = Expanded ? '1' : '0';
+	}
+	aState[Pos] = '\0';
+
+	while(Pos > 0 && aState[Pos - 1] == '1')
+	{
+		--Pos;
+		aState[Pos] = '\0';
+	}
+
+	if(str_comp(aState, g_Config.m_ClFriendsCategoryExpanded) != 0)
+		str_copy(g_Config.m_ClFriendsCategoryExpanded, aState, sizeof(g_Config.m_ClFriendsCategoryExpanded));
+
+	m_FriendsCategoryExpandedStateCache = g_Config.m_ClFriendsCategoryExpanded;
+	m_FriendsCategoryExpandedLoaded = true;
+}
+
 void CMenus::FriendlistOnUpdate()
 {
 	const int NumCategories = maximum(1, GameClient()->Friends()->NumCategories());
-	if((int)m_vFriendsCategoryExpanded.size() < NumCategories)
-		m_vFriendsCategoryExpanded.resize(NumCategories, true);
-	else if((int)m_vFriendsCategoryExpanded.size() > NumCategories)
-		m_vFriendsCategoryExpanded.resize(NumCategories);
+	const bool ConfigChanged = m_FriendsCategoryExpandedLoaded &&
+		str_comp(m_FriendsCategoryExpandedStateCache.c_str(), g_Config.m_ClFriendsCategoryExpanded) != 0;
+
+	if(!m_FriendsCategoryExpandedLoaded || ConfigChanged)
+	{
+		ApplyFriendsCategoryExpandedState();
+	}
+	else
+	{
+		if((int)m_vFriendsCategoryNames.size() != NumCategories)
+		{
+			std::vector<unsigned char> vExpanded(NumCategories, true);
+			for(int CategoryIndex = 0; CategoryIndex < NumCategories; ++CategoryIndex)
+			{
+				const char *pCategory = GameClient()->Friends()->GetCategory(CategoryIndex);
+				for(size_t PrevIndex = 0; PrevIndex < m_vFriendsCategoryNames.size(); ++PrevIndex)
+				{
+					if(str_comp_nocase(m_vFriendsCategoryNames[PrevIndex].c_str(), pCategory) == 0)
+					{
+						if(PrevIndex < m_vFriendsCategoryExpanded.size())
+							vExpanded[CategoryIndex] = m_vFriendsCategoryExpanded[PrevIndex];
+						break;
+					}
+				}
+			}
+			m_vFriendsCategoryExpanded.swap(vExpanded);
+			RefreshFriendsCategoryNames();
+			SaveFriendsCategoryExpandedState();
+		}
+		else
+		{
+			bool NamesChanged = false;
+			for(int CategoryIndex = 0; CategoryIndex < NumCategories; ++CategoryIndex)
+			{
+				const char *pCategory = GameClient()->Friends()->GetCategory(CategoryIndex);
+				if(str_comp(m_vFriendsCategoryNames[CategoryIndex].c_str(), pCategory) != 0)
+				{
+					NamesChanged = true;
+					break;
+				}
+			}
+
+			if(NamesChanged)
+			{
+				RefreshFriendsCategoryNames();
+				SaveFriendsCategoryExpandedState();
+			}
+			else if((int)m_vFriendsCategoryExpanded.size() < NumCategories)
+			{
+				m_vFriendsCategoryExpanded.resize(NumCategories, true);
+			}
+			else if((int)m_vFriendsCategoryExpanded.size() > NumCategories)
+			{
+				m_vFriendsCategoryExpanded.resize(NumCategories);
+			}
+		}
+	}
 
 	if(m_FriendAddCategoryIndex < 0 || m_FriendAddCategoryIndex >= NumCategories)
 		m_FriendAddCategoryIndex = 0;

--- a/src/game/client/components/tclient/menus_qmclient.cpp
+++ b/src/game/client/components/tclient/menus_qmclient.cpp
@@ -3757,14 +3757,71 @@ void CMenus::RenderSettingsQiMeng(CUIRect MainView)
 			RightContent.HSplitTop(1.0f, &Divider, &RightContent);
 			Divider.Draw(ColorRGBA(1.0f, 1.0f, 1.0f, 0.16f), IGraphics::CORNER_NONE, 0.0f);
 			RightContent.HSplitTop(LG_LineSpacing * 0.55f, nullptr, &RightContent);
-			RightContent.HSplitTop(LG_LineHeight * 0.96f, &Row, &RightContent);
 			//TextRender()->TextColor(GetRainbowColor(-8));//彩虹循环效果
 			TextRender()->TextColor(ColorRGBA(0.95f, 0.8f, 0.2f, 1.0f));
-			Ui()->DoLabel(&Row, "喵不一,久桃,芽芽,骨头,陌浅羽,树羽小朋友", LG_BodySize * 1.1f, TEXTALIGN_ML);
-			RightContent.HSplitTop(LG_LineHeight * 0.96f, &Row, &RightContent);
-			Ui()->DoLabel(&Row, "望舒,松子,平凡..,cixin,洗点,秀色,朱朱,Twen", LG_BodySize * 1.1f, TEXTALIGN_ML);
-			RightContent.HSplitTop(LG_LineHeight * 0.96f, &Row, &RightContent);
-			Ui()->DoLabel(&Row, "大恐龙,:luv:,见月,Blue°F,怯修,yezeen,鹑", LG_BodySize * 1.1f, TEXTALIGN_ML);
+			{
+				static const char *const s_apSponsors[] = {
+					"喵不一",
+					"久桃",
+					"芽芽",
+					"碳烤綿芽",
+					"骨头",
+					"陌浅羽",
+					"树羽小朋友",
+					"望舒",
+					"松子",
+					"平凡..",
+					"cixin",
+					"洗点",
+					"秀色",
+					"朱朱",
+					"Twen",
+					"大恐龙",
+					":luv:",
+					"见月",
+					"Blue°F",
+					"怯修",
+					"yezeen",
+					"鹑",
+				};
+				const float SponsorFontSize = LG_BodySize * 1.1f;
+				const float MaxLineWidth = RightContent.w;
+				const char *pSeparator = ",";
+				const float SeparatorWidth = TextRender()->TextWidth(SponsorFontSize, pSeparator);
+
+				std::vector<std::string> Lines;
+				Lines.emplace_back();
+				float LineWidth = 0.0f;
+				for(const char *pName : s_apSponsors)
+				{
+					const float NameWidth = TextRender()->TextWidth(SponsorFontSize, pName);
+					if(Lines.back().empty())
+					{
+						Lines.back() = pName;
+						LineWidth = NameWidth;
+						continue;
+					}
+
+					const float NextWidth = LineWidth + SeparatorWidth + NameWidth;
+					if(NextWidth > MaxLineWidth)
+					{
+						Lines.emplace_back(pName);
+						LineWidth = NameWidth;
+					}
+					else
+					{
+						Lines.back().append(pSeparator);
+						Lines.back().append(pName);
+						LineWidth = NextWidth;
+					}
+				}
+
+				for(const auto &Line : Lines)
+				{
+					RightContent.HSplitTop(LG_LineHeight * 0.96f, &Row, &RightContent);
+					Ui()->DoLabel(&Row, Line.c_str(), SponsorFontSize, TEXTALIGN_ML);
+				}
+			}
 			TextRender()->TextColor(TextRender()->DefaultTextColor());
 
 			RightContent.HSplitTop(LG_LineSpacing * 0.55f, nullptr, &RightContent);


### PR DESCRIPTION
feat(friends): 添加好友备注功能和分组展开状态保存

- 增加好友备注字段及相关接口，包括设置、获取和清除备注
- 添加控制台命令以支持好友备注的设置与清除
- 修改好友数据保存逻辑，支持备注信息的持久化
- 扩展好友列表界面，显示备注信息和服务器信息的组合提示
- 新增好友操作弹出菜单，支持编辑和清除备注功能
- 添加备注编辑弹窗，支持备注的输入和保存
- 实现好友分组展开状态的配置保存与加载功能
- 优化分组展开状态的缓存管理和变更检测
- 优化好友列表刷新逻辑，确保分组名称与展开状态同步

feat(client): 实现主线程卡死检测及报告导出

- 新增主线程心跳更新机制，用于周期性更新活动状态
- 实现独立线程监控主线程心跳，检测长时间无响应情况
- 支持生成卡死检测报告文本，包含客户端状态和地图信息
- 在Windows平台生成迷你Dump文件，便于调试和问题定位
- 自动创建报告与Dump文件存储目录
- 新增HangWatchdog启动与停止接口，确保线程安全管理
- 在客户端主循环及退出流程中集成心跳更新和监控停止逻辑

chore(config): 新增好友栏分类展开状态配置项

- 在配置文件添加cl_friends_category_expanded字符串变量
- 用于保存好友栏各分类的展开与收起状态，支持持久化读取与写入