### PR TITLE
Clion_QM

### DIFF
--- a/src/engine/shared/config_variables_tclient.h
+++ b/src/engine/shared/config_variables_tclient.h
@@ -98,6 +98,8 @@ MACRO_CONFIG_INT(QmUnfinishedMapAutoVote, qm_unfinished_map_auto_vote, 0, 0, 1, 
 // Outline Variables
 MACRO_CONFIG_INT(TcOutline, tc_outline, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Draws outlines")
 MACRO_CONFIG_INT(TcOutlineEntities, tc_outline_in_entities, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Only show outlines in entities")
+MACRO_CONFIG_INT(TcOutlineAlpha, tc_outline_alpha, 100, 0, 100, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Global outline opacity")
+MACRO_CONFIG_INT(TcOutlineSolidAlpha, tc_outline_solid_alpha, 100, 0, 100, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Opacity of solid wall outlines")
 
 MACRO_CONFIG_INT(TcOutlineSolid, tc_outline_solid, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Draws outline around hook and unhook")
 MACRO_CONFIG_INT(TcOutlineFreeze, tc_outline_freeze, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Draws outline around freeze and deep")

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -973,7 +973,12 @@ void CHud::RenderSwapCountdown()
 		return;
 
 	static constexpr int SWAP_COUNTDOWN_SECONDS = 30;
-	const int SecondsLeft = SWAP_COUNTDOWN_SECONDS - (ElapsedTicks / TickSpeed);
+	static constexpr int SWAP_HIDE_AFTER_SECONDS = SWAP_COUNTDOWN_SECONDS + 60;
+	const int ElapsedSeconds = ElapsedTicks / TickSpeed;
+	if(ElapsedSeconds >= SWAP_HIDE_AFTER_SECONDS)
+		return;
+
+	const int SecondsLeft = SWAP_COUNTDOWN_SECONDS - ElapsedSeconds;
 
 	const float FontSize = 8.0f;
 	const float X = 5.0f;

--- a/src/game/client/components/tclient/menus_qmclient.cpp
+++ b/src/game/client/components/tclient/menus_qmclient.cpp
@@ -1093,6 +1093,10 @@ void CMenus::RenderSettingsTClientSettings(CUIRect MainView)
 
 	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_TcOutline, TCLocalize("显示所有启用的轮廓"), &g_Config.m_TcOutline, &Column, LineSize);
 	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_TcOutlineEntities, TCLocalize("仅在实体层中显示轮廓"), &g_Config.m_TcOutlineEntities, &Column, LineSize);
+	Column.HSplitTop(LineSize, &Button, &Column);
+	Ui()->DoScrollbarOption(&g_Config.m_TcOutlineAlpha, &g_Config.m_TcOutlineAlpha, &Button, TCLocalize("轮廓透明度"), 0, 100, &CUi::ms_LinearScrollbarScale, 0, "%");
+	Column.HSplitTop(LineSize, &Button, &Column);
+	Ui()->DoScrollbarOption(&g_Config.m_TcOutlineSolidAlpha, &g_Config.m_TcOutlineSolidAlpha, &Button, TCLocalize("墙体轮廓透明度"), 0, 100, &CUi::ms_LinearScrollbarScale, 0, "%");
 
 	auto DoOutlineType = [&](CButtonContainer &ButtonContainer, const char *pName, int &Enable, int &Width, unsigned int &Color, const unsigned int &ColorDefault) {
 		// Checkbox & Color

--- a/src/game/client/components/tclient/outlines.cpp
+++ b/src/game/client/components/tclient/outlines.cpp
@@ -265,7 +265,15 @@ void COutlines::OnRender()
 			}
 			if(NumQuads <= 0)
 				continue;
-			Graphics()->SetColor(color_cast<ColorRGBA>(ColorHSLA(Config.m_Color, true)));
+
+			ColorRGBA OutlineColor = color_cast<ColorRGBA>(ColorHSLA(Config.m_Color, true));
+			OutlineColor.a *= g_Config.m_TcOutlineAlpha / 100.0f;
+			if(Type == OUTLINE_SOLID)
+				OutlineColor.a *= g_Config.m_TcOutlineSolidAlpha / 100.0f;
+			if(OutlineColor.a <= 0.0f)
+				continue;
+
+			Graphics()->SetColor(OutlineColor);
 			Graphics()->QuadsDrawTL(aQuads, NumQuads);
 		}
 	}


### PR DESCRIPTION
client: 重构 QmClient UI 并整合媒体/歌词/轮廓配置

- 重构客户端 UI 与菜单相关实现，调整 menus、menus_browser、HUD 与多处组件联动
- 新增歌词组件与系统媒体控制相关能力，扩展设置项与显示逻辑
- 新增输入覆盖资源与默认配置（input overlay Zac 方案）
- 引入 qmclient_center_server 脚本目录（Node 服务端脚本与依赖）
- 清理/替换旧模块：移除 start_menu rml/rcss、sidebar、menu_particles、stt 实现
- 调整 friends/nameplates/collision/render_layer/gameclient 等核心逻辑与配置映射
- 增加墙体轮廓模块透明度能力：全局轮廓透明度 + 墙体轮廓透明度，并在设置界面提供滑条
- 更新配置变量、构建与说明文件（config/CMake/README/version）