### PR TITLE
feat(qmclient): 增强断言和挂起日志，新增Deepfly模式

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -142,7 +142,7 @@ void dbg_assert_imp(const char *filename, int line, const char *fmt, ...)
 	va_start(args, fmt);
 	str_format_v(msg, sizeof(msg), fmt, args);
 	char error[1024];
-	str_format(error, sizeof(error), "%s(%d): %s", filename, line, msg);
+	str_format(error, sizeof(error), "%s(%d): %s", fs_filename(filename), line, msg);
 	va_end(args);
 	log_error("assert", "%s", error);
 	if(!already_failing)

--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -7518,8 +7518,8 @@ public:
 #ifdef CONF_PLATFORM_ANDROID
 			if(!CreateSurface(m_pWindow))
 				return false;
-			m_RecreateSwapChain = true;
 #endif
+			m_RecreateSwapChain = true;
 			m_RenderingPaused = false;
 			if(!PureMemoryFrame())
 				return false;
@@ -7539,9 +7539,7 @@ public:
 				return false;
 			m_RenderingPaused = true;
 			vkDeviceWaitIdle(m_VKDevice);
-#ifdef CONF_PLATFORM_ANDROID
 			CleanupVulkanSwapChain(true);
-#endif
 		}
 
 		return true;

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -1704,7 +1704,10 @@ int CGraphicsBackend_SDL_GL::WindowActive()
 
 int CGraphicsBackend_SDL_GL::WindowOpen()
 {
-	return m_pWindow && SDL_GetWindowFlags(m_pWindow) & SDL_WINDOW_SHOWN;
+	if(!m_pWindow)
+		return false;
+	const uint32_t WindowFlags = SDL_GetWindowFlags(m_pWindow);
+	return (WindowFlags & SDL_WINDOW_SHOWN) != 0 && (WindowFlags & SDL_WINDOW_MINIMIZED) == 0;
 }
 
 void CGraphicsBackend_SDL_GL::SetWindowGrab(bool Grab)

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -91,6 +91,7 @@ using namespace std::chrono_literals;
 static constexpr ColorRGBA gs_ClientNetworkPrintColor{0.7f, 1, 0.7f, 1.0f};
 static constexpr ColorRGBA gs_ClientNetworkErrPrintColor{1.0f, 0.25f, 0.25f, 1.0f};
 static constexpr int64_t gs_HangTimeoutSeconds = 10;
+static constexpr const char *gs_pQmCrashDumpDir = "dumps/QmClient_Crash";
 
 static const char *ClientStateToString(int State)
 {
@@ -3553,8 +3554,6 @@ void CClient::Run()
 		m_GlobalTime = (time_get() - m_GlobalStartTime) / (float)time_freq();
 	}
 
-	StopHangWatchdog();
-
 	GameClient()->RenderShutdownMessage();
 	Disconnect();
 
@@ -3579,6 +3578,11 @@ void CClient::Run()
 	m_Http.Shutdown();
 	Engine()->ShutdownJobs();
 
+	// Stop the hang watchdog AFTER ShutdownJobs() so that hangs occurring
+	// during the shutdown sequence (e.g. a stuck non-abortable job) are
+	// still detected and reported while we wait.
+	StopHangWatchdog();
+
 	GameClient()->RenderShutdownMessage();
 	GameClient()->OnShutdown();
 	delete m_pEditor;
@@ -3589,6 +3593,7 @@ void CClient::Run()
 
 	// shutdown text render while graphics are still available
 	m_pTextRender->Shutdown();
+
 }
 
 bool CClient::InitNetworkClient(char *pError, size_t ErrorSize)
@@ -4227,6 +4232,13 @@ void CClient::DemoRecorder_Start(const char *pFilename, bool WithTimestamp, int 
 			m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "demorec/record", "client is not online");
 		}
 	}
+	else if(!m_pMap || !m_pMap->IsLoaded())
+	{
+		if(Verbose)
+		{
+			m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "demorec/record", "map is not loaded yet");
+		}
+	}
 	else
 	{
 		char aFilename[IO_MAX_PATH_LENGTH];
@@ -4352,7 +4364,7 @@ void CClient::StartHangWatchdog()
 	m_HangWatchdogStop.store(false, std::memory_order_release);
 	m_HangReportWritten.store(false, std::memory_order_release);
 	if(m_aHangDumpDir[0] == '\0' && Storage() != nullptr)
-		Storage()->GetCompletePath(IStorage::TYPE_SAVE, "dumps", m_aHangDumpDir, sizeof(m_aHangDumpDir));
+		Storage()->GetCompletePath(IStorage::TYPE_SAVE, gs_pQmCrashDumpDir, m_aHangDumpDir, sizeof(m_aHangDumpDir));
 	UpdateHangHeartbeat();
 
 	if(m_HangWatchdogThread.joinable())
@@ -4426,12 +4438,30 @@ void CClient::WriteHangReportAndDump(int64_t Now, int64_t LastHeartbeat)
 		const int SnapshotIndex = m_HangInfoIndex.load(std::memory_order_acquire);
 		const SHangInfo Snapshot = m_aHangInfo[SnapshotIndex];
 		const float SecondsSinceHeartbeat = (Now - LastHeartbeat) / (float)time_freq();
+		char aOsVersion[128];
+		if(!os_version_str(aOsVersion, sizeof(aOsVersion)))
+			str_copy(aOsVersion, "unknown");
 
-		char aBuf[1024];
-		str_format(aBuf, sizeof(aBuf), "Hang detected (no main thread heartbeat for %.1f seconds)\n", SecondsSinceHeartbeat);
+		char aBuf[2048];
+		str_copy(aBuf, "QmClient hang diagnostic report\n");
+		io_write(File, aBuf, str_length(aBuf));
+
+		str_copy(aBuf, "Report type: hang\n");
 		io_write(File, aBuf, str_length(aBuf));
 
 		str_format(aBuf, sizeof(aBuf), "Timestamp: %s\n", aDate);
+		io_write(File, aBuf, str_length(aBuf));
+
+		str_format(aBuf, sizeof(aBuf), "Process ID: %d\n", pid());
+		io_write(File, aBuf, str_length(aBuf));
+
+		str_format(aBuf, sizeof(aBuf), "Hang timeout threshold: %lld seconds\n", (long long)gs_HangTimeoutSeconds);
+		io_write(File, aBuf, str_length(aBuf));
+
+		str_format(aBuf, sizeof(aBuf), "No heartbeat duration: %.1f seconds\n", SecondsSinceHeartbeat);
+		io_write(File, aBuf, str_length(aBuf));
+
+		str_format(aBuf, sizeof(aBuf), "Heartbeat ticks: now=%lld, last=%lld, delta=%lld\n", (long long)Now, (long long)LastHeartbeat, (long long)(Now - LastHeartbeat));
 		io_write(File, aBuf, str_length(aBuf));
 
 		str_format(aBuf, sizeof(aBuf), "Client state: %s (%d)\n", ClientStateToString(Snapshot.m_State), Snapshot.m_State);
@@ -4443,7 +4473,13 @@ void CClient::WriteHangReportAndDump(int64_t Now, int64_t LastHeartbeat)
 		str_format(aBuf, sizeof(aBuf), "Server address: %s\n", Snapshot.m_aServerAddr);
 		io_write(File, aBuf, str_length(aBuf));
 
+		str_format(aBuf, sizeof(aBuf), "OS version: %s\n", aOsVersion);
+		io_write(File, aBuf, str_length(aBuf));
+
 		str_format(aBuf, sizeof(aBuf), "Game version: %s %s %s\n", GAME_NAME, GAME_RELEASE_VERSION, GIT_SHORTREV_HASH != nullptr ? GIT_SHORTREV_HASH : "");
+		io_write(File, aBuf, str_length(aBuf));
+
+		str_format(aBuf, sizeof(aBuf), "Report directory: %s\n", m_aHangDumpDir);
 		io_write(File, aBuf, str_length(aBuf));
 
 		io_sync(File);
@@ -5048,7 +5084,7 @@ int main(int argc, const char **argv)
 #if defined(CONF_CRASHDUMP)
 			" and crash log"
 #endif
-			" which you should find in the 'dumps' folder in your config directory.\n\n"
+			" which you should find in the 'dumps/QmClient_Crash' folder in your config directory.\n\n"
 			"%s\n\n"
 			"Platform: %s (%s)\n"
 			"Configuration: base"
@@ -5086,7 +5122,7 @@ int main(int argc, const char **argv)
 #if !defined(CONF_PLATFORM_ANDROID)
 		if(pClient->Storage() != nullptr)
 		{
-			vButtons.push_back({.m_pLabel = "Show dumps"});
+			vButtons.push_back({.m_pLabel = "Show crash reports"});
 		}
 #endif
 		vButtons.push_back({.m_pLabel = "OK", .m_Confirm = true, .m_Cancel = true});
@@ -5095,7 +5131,7 @@ int main(int argc, const char **argv)
 		if(pClient->Storage() != nullptr && MessageResult && *MessageResult == 0)
 		{
 			char aDumpsPath[IO_MAX_PATH_LENGTH];
-			pClient->Storage()->GetCompletePath(IStorage::TYPE_SAVE, "dumps", aDumpsPath, sizeof(aDumpsPath));
+			pClient->Storage()->GetCompletePath(IStorage::TYPE_SAVE, gs_pQmCrashDumpDir, aDumpsPath, sizeof(aDumpsPath));
 			pClient->ViewFile(aDumpsPath);
 		}
 #else
@@ -5138,7 +5174,7 @@ int main(int argc, const char **argv)
 		char aBufName[IO_MAX_PATH_LENGTH];
 		char aDate[64];
 		str_timestamp(aDate, sizeof(aDate));
-		str_format(aBufName, sizeof(aBufName), "dumps/" GAME_NAME "_%s_crash_log_%s_%d_%s.RTP", CONF_PLATFORM_STRING, aDate, pid(), GIT_SHORTREV_HASH != nullptr ? GIT_SHORTREV_HASH : "");
+		str_format(aBufName, sizeof(aBufName), "%s/" GAME_NAME "_%s_crash_log_%s_%d_%s.RTP", gs_pQmCrashDumpDir, CONF_PLATFORM_STRING, aDate, pid(), GIT_SHORTREV_HASH != nullptr ? GIT_SHORTREV_HASH : "");
 		pStorage->GetCompletePath(IStorage::TYPE_SAVE, aBufName, aBufPath, sizeof(aBufPath));
 		crashdump_init_if_available(aBufPath);
 	}
@@ -5354,11 +5390,15 @@ const char *CClient::GetCurrentMapPath() const
 
 SHA256_DIGEST CClient::GetCurrentMapSha256() const
 {
+	if(!m_pMap || !m_pMap->IsLoaded())
+		return SHA256_ZEROED;
 	return m_pMap->Sha256();
 }
 
 unsigned CClient::GetCurrentMapCrc() const
 {
+	if(!m_pMap || !m_pMap->IsLoaded())
+		return 0;
 	return m_pMap->Crc();
 }
 
@@ -5366,6 +5406,8 @@ void CClient::RaceRecord_Start(const char *pFilename)
 {
 	if(State() != IClient::STATE_ONLINE)
 		m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "demorec/record", "client is not online");
+	else if(!m_pMap || !m_pMap->IsLoaded())
+		m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "demorec/record", "map is not loaded yet");
 	else
 		m_aDemoRecorder[RECORDER_RACE].Start(
 			Storage(),

--- a/src/engine/shared/assertion_logger.cpp
+++ b/src/engine/shared/assertion_logger.cpp
@@ -57,6 +57,21 @@ void CAssertionLogger::Dump()
 	IOHANDLE FileHandle = io_open(aAssertLogFile, IOFLAG_WRITE);
 	if(FileHandle)
 	{
+		char aOsVersion[128];
+		if(!os_version_str(aOsVersion, sizeof(aOsVersion)))
+			str_copy(aOsVersion, "unknown");
+		char aHeader[1024];
+		str_format(aHeader, sizeof(aHeader),
+			"QmClient assertion diagnostic log\n"
+			"Timestamp: %s\n"
+			"Process ID: %d\n"
+			"Game name: %s\n"
+			"OS version: %s\n"
+			"Log path: %s\n\n"
+			"Recent log lines before the assertion:\n",
+			aDate, pid(), m_aGameName, aOsVersion, m_aAssertLogPath);
+		io_write(FileHandle, aHeader, str_length(aHeader));
+
 		auto *pIt = m_DbgMessages.First();
 		while(pIt)
 		{
@@ -80,6 +95,6 @@ CAssertionLogger::CAssertionLogger(const char *pAssertLogPath, const char *pGame
 std::unique_ptr<ILogger> CreateAssertionLogger(IStorage *pStorage, const char *pGameName)
 {
 	char aAssertLogPath[IO_MAX_PATH_LENGTH];
-	pStorage->GetCompletePath(IStorage::TYPE_SAVE, "dumps/", aAssertLogPath, sizeof(aAssertLogPath));
+	pStorage->GetCompletePath(IStorage::TYPE_SAVE, "dumps/QmClient_Crash/", aAssertLogPath, sizeof(aAssertLogPath));
 	return std::make_unique<CAssertionLogger>(aAssertLogPath, pGameName);
 }

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -71,6 +71,7 @@ MACRO_CONFIG_INT(ClShowhudDummyActions, cl_showhud_dummy_actions, 1, 0, 1, CFGFL
 MACRO_CONFIG_INT(ClShowhudKeyStatusReset, cl_showhud_key_status_reset, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "显示游戏内 HUD（卡键状态）")
 MACRO_CONFIG_INT(ClShowhudKeyStatusHammer, cl_showhud_key_status_hammer, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "显示游戏内 HUD（锤状态）")
 MACRO_CONFIG_INT(ClShowhudKeyStatusControl, cl_showhud_key_status_control, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "显示游戏内 HUD（分身控制状态）")
+MACRO_CONFIG_INT(ClShowhudKeyStatusSync, cl_showhud_key_status_sync, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "显示游戏内 HUD（分身同步状态）")
 MACRO_CONFIG_INT(ClShowhudPlayerPosition, cl_showhud_player_position, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "显示游戏内 HUD（玩家位置）")
 MACRO_CONFIG_INT(ClShowhudPlayerSpeed, cl_showhud_player_speed, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "显示游戏内 HUD（玩家速度）")
 MACRO_CONFIG_INT(ClShowhudPlayerAngle, cl_showhud_player_angle, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "显示游戏内 HUD（玩家瞄准角度）")

--- a/src/engine/shared/config_variables_tclient.h
+++ b/src/engine/shared/config_variables_tclient.h
@@ -301,6 +301,8 @@ MACRO_CONFIG_INT(TcPetAlpha, tc_pet_alpha, 90, 10, 100, CFGFLAG_CLIENT | CFGFLAG
 // Change name near finish
 MACRO_CONFIG_INT(TcChangeNameNearFinish, tc_change_name_near_finish, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Attempt to change your name when near finish")
 MACRO_CONFIG_STR(TcFinishName, tc_finish_name, 16, "nameless tee", CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_INSENSITIVE, "Name to change to when near finish when tc_change_name_near_finish is 1")
+MACRO_CONFIG_STR(TcFinishNameQueue, tc_finish_name_queue, 256, "", CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_INSENSITIVE, "Ordered finish name queue separated by |, comma, semicolon or newline")
+MACRO_CONFIG_INT(TcFinishNameRequireOwnFinished, tc_finish_name_require_own_finished, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Don't change name near finish if your own configured name has not finished the map")
 
 // Flags
 MACRO_CONFIG_INT(TcTClientSettingsTabs, tc_tclient_settings_tabs, 0, 0, 65536, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Bit flags to disable settings tabs")
@@ -421,7 +423,12 @@ MACRO_CONFIG_INT(QmClientMarkTrail, qm_client_mark_trail, 1, 0, 1, CFGFLAG_CLIEN
 // QiaFen (恰分) Module / 恰分模块
 MACRO_CONFIG_INT(QmQiaFenEnabled, qm_qiafen_enabled, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "启用恰分模块 (Enable QiaFen auto-response)")
 MACRO_CONFIG_INT(QmQiaFenUseDummy, qm_qiafen_use_dummy, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "恰分发言使用Dummy (Use dummy for QiaFen replies)")
+MACRO_CONFIG_STR(QmQiaFenRules, qm_qiafen_rules, 2048, "", CFGFLAG_CLIENT | CFGFLAG_SAVE, "恰分规则（每行: 关键词=>回复）")
 MACRO_CONFIG_STR(QmQiaFenKeywords, qm_qiafen_keywords, 512, "", CFGFLAG_CLIENT | CFGFLAG_SAVE, "恰分自定义识别词（用,分隔）")
+MACRO_CONFIG_INT(QmKeywordReplyEnabled, qm_keyword_reply_enabled, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "启用关键词回复")
+MACRO_CONFIG_INT(QmKeywordReplyUseDummy, qm_keyword_reply_use_dummy, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "关键词回复使用Dummy")
+MACRO_CONFIG_STR(QmKeywordReplyRules, qm_keyword_reply_rules, 4096, "", CFGFLAG_CLIENT | CFGFLAG_SAVE, "关键词回复规则（每行: 关键词=>回复）")
+MACRO_CONFIG_INT(QmAutoReplyCooldown, qm_auto_reply_cooldown, 3, 0, 30, CFGFLAG_CLIENT | CFGFLAG_SAVE, "自动回复冷却时间（秒）")
 
 // Pie Menu / 饼菜单
 MACRO_CONFIG_INT(QmPieMenuEnabled, qm_pie_menu_enabled, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "启用饼菜单 (Enable pie menu for player interactions)")
@@ -437,11 +444,13 @@ MACRO_CONFIG_INT(QmPieMenuColorSpectate, qm_pie_menu_color_spectate, 0x738C99BF,
 
 // Repeat Message / 复读功能
 MACRO_CONFIG_INT(QmRepeatEnabled, qm_repeat_enabled, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "启用复读功能 (Enable repeat last message)")
+MACRO_CONFIG_INT(QmRepeatAutoAddOne, qm_repeat_auto_add_one, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "自动加一（出现二句及以上非自己发送的相同消息时自动发送）")
 MACRO_CONFIG_INT(QmRepeatKey, qm_repeat_key, 278, 0, 512, CFGFLAG_CLIENT | CFGFLAG_SAVE, "复读快捷键 (Repeat key, default: Home=278)")
 MACRO_CONFIG_INT(QmSayNoPop, qm_say_nopop, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "输入时不显示打字表情 (Hide typing emoticon while chatting)")
 MACRO_CONFIG_INT(QmHammerSwapSkin, qm_hammer_swap_skin, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "锤人换皮肤 (Copy target skin on hammer hit)")
 MACRO_CONFIG_INT(QmRandomEmoteOnHit, qm_random_emote_on_hit, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "被锤/榴弹击中时随机表情 (Random emote on hammer/grenade hit)")
 MACRO_CONFIG_INT(QmWeaponTrajectory, qm_weapon_trajectory, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "启用武器弹道辅助线 (Enable weapon trajectory)")
+MACRO_CONFIG_INT(QmDeepflyMode, qm_deepfly_mode, 0, 0, 3, CFGFLAG_CLIENT, "Deepfly模式（0=正常，1=DF，2=HDF，3=自定义）")
 
 // Auto Unspec on Unfreeze / 解冻自动取消旁观
 MACRO_CONFIG_INT(QmAutoUnspecOnUnfreeze, qm_auto_unspec_on_unfreeze, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "被解冻时自动取消旁观 (Auto exit spectator mode when unfrozen)")
@@ -467,6 +476,8 @@ MACRO_CONFIG_INT(QmStreamerScoreboardDefaultFlags, qm_streamer_scoreboard_defaul
 MACRO_CONFIG_INT(QmFriendOnlineNotify, qm_friend_online_notify, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "好友上线提醒")
 MACRO_CONFIG_INT(QmFriendOnlineAutoRefresh, qm_friend_online_auto_refresh, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "好友提醒自动刷新服务器列表")
 MACRO_CONFIG_INT(QmFriendOnlineRefreshSeconds, qm_friend_online_refresh_seconds, 30, 5, 300, CFGFLAG_CLIENT | CFGFLAG_SAVE, "好友提醒刷新间隔(秒)")
+MACRO_CONFIG_INT(QmFriendEnterAutoGreet, qm_friend_enter_auto_greet, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "好友进图自动打招呼")
+MACRO_CONFIG_STR(QmFriendEnterGreetText, qm_friend_enter_greet_text, 128, "你好啊!", CFGFLAG_CLIENT | CFGFLAG_SAVE, "好友进图自动打招呼文本")
 
 // Block Words / 屏蔽词
 MACRO_CONFIG_INT(QmBlockWordsEnabled, qm_block_words_enabled, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "启用屏蔽词列表")

--- a/src/engine/shared/jobs.cpp
+++ b/src/engine/shared/jobs.cpp
@@ -2,7 +2,10 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "jobs.h"
 
+#include <base/log.h>
+
 #include <algorithm>
+#include <chrono>
 
 IJob::IJob() :
 	m_pNext(nullptr),
@@ -124,6 +127,13 @@ void CJobPool::RunLoop()
 			break;
 		}
 	}
+
+	// Notify Shutdown() that this worker thread is about to exit.
+	{
+		std::lock_guard<std::mutex> Lock(m_ShutdownWaitMutex);
+		m_ActiveThreadCount.fetch_sub(1, std::memory_order_release);
+	}
+	m_ShutdownWaitCv.notify_all();
 }
 
 void CJobPool::Init(int NumThreads)
@@ -139,6 +149,7 @@ void CJobPool::Init(int NumThreads)
 	// start worker threads
 	char aName[16]; // unix kernel length limit
 	m_vpThreads.reserve(NumThreads);
+	m_ActiveThreadCount.store(NumThreads, std::memory_order_release);
 	for(int i = 0; i < NumThreads; i++)
 	{
 		str_format(aName, sizeof(aName), "CJobPool W%d", i);
@@ -196,10 +207,27 @@ void CJobPool::Shutdown()
 		sphore_signal(&m_Semaphore);
 	}
 
-	// wait for all worker threads to finish
+	// Wait up to 5 seconds for all worker threads to finish.
+	// If a non-abortable job is still running after the timeout, we detach the
+	// remaining threads instead of blocking the shutdown sequence indefinitely.
+	// The process is about to exit anyway, so the OS will clean up the threads.
+	{
+		std::unique_lock<std::mutex> Lock(m_ShutdownWaitMutex);
+		const bool AllDone = m_ShutdownWaitCv.wait_for(Lock, std::chrono::seconds(5),
+			[this]() { return m_ActiveThreadCount.load(std::memory_order_acquire) == 0; });
+		if(!AllDone)
+		{
+			log_warn("jobpool", "shutdown timed out after 5 seconds, %d worker thread(s) did not finish in time, detaching",
+				m_ActiveThreadCount.load(std::memory_order_relaxed));
+		}
+	}
+
+	// Detach all threads. Threads that already exited are simply reclaimed;
+	// threads that are still running will continue until they finish and
+	// have their resources freed automatically.
 	for(void *pThread : m_vpThreads)
 	{
-		thread_wait(pThread);
+		thread_detach(pThread);
 	}
 
 	m_vpThreads.clear();

--- a/src/engine/shared/jobs.h
+++ b/src/engine/shared/jobs.h
@@ -7,8 +7,10 @@
 #include <base/system.h>
 
 #include <atomic>
+#include <condition_variable>
 #include <deque>
 #include <memory>
+#include <mutex>
 #include <vector>
 
 /**
@@ -136,6 +138,11 @@ class CJobPool
 
 	CLock m_LockRunning;
 	std::deque<std::shared_ptr<IJob>> m_RunningJobs GUARDED_BY(m_LockRunning);
+
+	// Shutdown coordination: used to implement a timed wait during Shutdown().
+	std::mutex m_ShutdownWaitMutex;
+	std::condition_variable m_ShutdownWaitCv;
+	std::atomic<int> m_ActiveThreadCount;
 
 	static void WorkerThread(void *pUser) NO_THREAD_SAFETY_ANALYSIS;
 	void RunLoop() NO_THREAD_SAFETY_ANALYSIS;

--- a/src/engine/shared/map.cpp
+++ b/src/engine/shared/map.cpp
@@ -142,21 +142,29 @@ bool CMap::IsLoaded() const
 
 IOHANDLE CMap::File() const
 {
+	if(!IsLoaded())
+		return nullptr;
 	return m_DataFile.File();
 }
 
 SHA256_DIGEST CMap::Sha256() const
 {
+	if(!IsLoaded())
+		return SHA256_ZEROED;
 	return m_DataFile.Sha256();
 }
 
 unsigned CMap::Crc() const
 {
+	if(!IsLoaded())
+		return 0;
 	return m_DataFile.Crc();
 }
 
 int CMap::MapSize() const
 {
+	if(!IsLoaded())
+		return 0;
 	return m_DataFile.MapSize();
 }
 

--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -100,6 +100,7 @@ public:
 
 		static constexpr const char *COMMON_DIRS[] = {
 			"dumps",
+			"dumps/QmClient_Crash",
 			"demos",
 			"demos/auto",
 			"demos/auto/race",

--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -14,6 +14,96 @@
 
 static constexpr LOG_COLOR BIND_PRINT_COLOR{255, 255, 204};
 
+enum EDeepflyMode
+{
+	DEEPFLY_MODE_NONE = -1,
+	DEEPFLY_MODE_NORMAL = 0,
+	DEEPFLY_MODE_DF = 1,
+	DEEPFLY_MODE_HDF = 2,
+	DEEPFLY_MODE_CUSTOM = 3,
+};
+
+static void NormalizeBindCommand(const char *pCommand, char *pNormalized, size_t NormalizedSize)
+{
+	size_t OutLen = 0;
+	bool PendingSpace = false;
+
+	while(*pCommand != '\0' && str_isspace(*pCommand))
+		++pCommand;
+
+	while(*pCommand != '\0' && OutLen + 1 < NormalizedSize)
+	{
+		if(str_isspace(*pCommand))
+		{
+			PendingSpace = OutLen > 0;
+		}
+		else
+		{
+			if(PendingSpace && OutLen + 1 < NormalizedSize)
+			{
+				pNormalized[OutLen++] = ' ';
+				PendingSpace = false;
+			}
+			pNormalized[OutLen++] = *pCommand;
+		}
+		++pCommand;
+	}
+
+	while(OutLen > 0 && pNormalized[OutLen - 1] == ' ')
+		--OutLen;
+	pNormalized[OutLen] = '\0';
+}
+
+static int DetectDeepflyModeFromBindCommand(const char *pCommand)
+{
+	if(!pCommand || pCommand[0] == '\0')
+		return DEEPFLY_MODE_NONE;
+
+	char aCommand[1024];
+	str_copy(aCommand, pCommand, sizeof(aCommand));
+
+	bool HasFire = false;
+	bool HasDummyHammerToggle = false;
+	bool HasOtherCommand = false;
+
+	char *pCursor = aCommand;
+	while(*pCursor != '\0')
+	{
+		char *pEnd = pCursor;
+		while(*pEnd != '\0' && *pEnd != ';')
+			++pEnd;
+
+		const bool HasNextCommand = *pEnd == ';';
+		*pEnd = '\0';
+
+		char aNormalized[1024];
+		NormalizeBindCommand(pCursor, aNormalized, sizeof(aNormalized));
+		if(aNormalized[0] != '\0')
+		{
+			if(str_comp_nocase(aNormalized, "+fire") == 0)
+				HasFire = true;
+			else if(str_comp_nocase(aNormalized, "+toggle cl_dummy_hammer 1 0") == 0)
+				HasDummyHammerToggle = true;
+			else
+				HasOtherCommand = true;
+		}
+
+		if(!HasNextCommand)
+			break;
+		pCursor = pEnd + 1;
+	}
+
+	if(!HasFire && !HasDummyHammerToggle)
+		return DEEPFLY_MODE_NONE;
+	if(HasOtherCommand)
+		return DEEPFLY_MODE_CUSTOM;
+	if(HasFire && HasDummyHammerToggle)
+		return DEEPFLY_MODE_DF;
+	if(HasDummyHammerToggle)
+		return DEEPFLY_MODE_HDF;
+	return DEEPFLY_MODE_NORMAL;
+}
+
 bool CBinds::CBindsSpecial::OnInput(const IInput::CEvent &Event)
 {
 	if((Event.m_Flags & (IInput::FLAG_PRESS | IInput::FLAG_RELEASE)) == 0)
@@ -64,6 +154,12 @@ void CBinds::Bind(int KeyId, const char *pStr, bool FreeOnly, int ModifierCombin
 		m_aapKeyBindings[ModifierCombination][KeyId] = (char *)malloc(Size);
 		str_copy(m_aapKeyBindings[ModifierCombination][KeyId], pStr, Size);
 		log_info_color(BIND_PRINT_COLOR, "binds", "bound %s = %s", aBindName, m_aapKeyBindings[ModifierCombination][KeyId]);
+	}
+
+	const int DeepflyMode = DetectDeepflyModeFromBindCommand(pStr);
+	if(DeepflyMode != DEEPFLY_MODE_NONE)
+	{
+		g_Config.m_QmDeepflyMode = DeepflyMode;
 	}
 }
 

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -1917,6 +1917,8 @@ struct SKeyStatusLines
 	bool m_ShowHammer;
 	char m_aControlLine[64];
 	bool m_ShowControl;
+	char m_aSyncLine[64];
+	bool m_ShowSync;
 };
 
 struct SKeyStatusLayout
@@ -1931,48 +1933,61 @@ struct SKeyStatusLayout
 	float m_PaddingY;
 };
 
-SKeyStatusLines GetKeyStatusLines(const CGameClient *pGameClient)
+constexpr float KEY_STATUS_RIGHT_MARGIN = 0.0f;
+
+SKeyStatusLines GetKeyStatusLines()
 {
 	SKeyStatusLines Lines{};
 	Lines.m_ShowKey = g_Config.m_ClShowhudKeyStatusReset != 0;
 	Lines.m_ShowHammer = g_Config.m_ClShowhudKeyStatusHammer != 0;
 	Lines.m_ShowControl = g_Config.m_ClShowhudKeyStatusControl != 0;
+	Lines.m_ShowSync = g_Config.m_ClShowhudKeyStatusSync != 0;
 
 	if(Lines.m_ShowKey)
 	{
 		Lines.m_pKeyStatusText = "卡键: ?";
 		if(g_Config.m_ClDummyResetOnSwitch == 0)
-			Lines.m_pKeyStatusText = "卡键: ON";
+			Lines.m_pKeyStatusText = "卡键: 开";
 		else if(g_Config.m_ClDummyResetOnSwitch == 1)
-			Lines.m_pKeyStatusText = "卡键: OFF";
+			Lines.m_pKeyStatusText = "卡键: 关";
 		else if(g_Config.m_ClDummyResetOnSwitch == 2)
 			Lines.m_pKeyStatusText = "卡键: 重置本体";
 	}
 
 	if(Lines.m_ShowHammer)
 	{
-		const bool FirePressed = (pGameClient->m_Controls.m_aInputData[g_Config.m_ClDummy].m_Fire & 1) != 0;
-		const char *pHammerState = g_Config.m_ClDummyHammer ? (FirePressed ? "DF" : "HDF") : "正常锤";
+		const char *pHammerState = "正常";
+		if(g_Config.m_QmDeepflyMode == 1)
+			pHammerState = "DF";
+		else if(g_Config.m_QmDeepflyMode == 2)
+			pHammerState = "HDF";
+		else if(g_Config.m_QmDeepflyMode == 3)
+			pHammerState = "自定义";
 		str_format(Lines.m_aHammerLine, sizeof(Lines.m_aHammerLine), "锤: %s", pHammerState);
 	}
 
 	if(Lines.m_ShowControl)
 	{
-		const char *pControlState = g_Config.m_ClDummyControl ? "开启" : "关闭";
+		const char *pControlState = g_Config.m_ClDummyControl ? "开" : "关";
 		str_format(Lines.m_aControlLine, sizeof(Lines.m_aControlLine), "分身控制: %s", pControlState);
+	}
+
+	if(Lines.m_ShowSync)
+	{
+		const char *pSyncState = g_Config.m_ClDummyCopyMoves ? "开" : "关";
+		str_format(Lines.m_aSyncLine, sizeof(Lines.m_aSyncLine), "分身同步: %s", pSyncState);
 	}
 
 	return Lines;
 }
 
-SKeyStatusLayout GetKeyStatusLayout(ITextRender *pTextRender, const SKeyStatusLines &Lines)
+SKeyStatusLayout GetKeyStatusLayout(ITextRender *pTextRender, const SKeyStatusLines &Lines, float HudWidth)
 {
 	SKeyStatusLayout Layout{};
 	Layout.m_FontSize = 7.0f;
 	Layout.m_LineHeight = 9.0f;
 	Layout.m_PaddingX = 4.0f;
 	Layout.m_PaddingY = 3.0f;
-	Layout.m_X = 476.0f;
 	Layout.m_Y = 38.0f;
 
 	int LineCount = 0;
@@ -1992,6 +2007,11 @@ SKeyStatusLayout GetKeyStatusLayout(ITextRender *pTextRender, const SKeyStatusLi
 		MaxWidth = maximum(MaxWidth, pTextRender->TextWidth(Layout.m_FontSize, Lines.m_aControlLine, -1, -1.0f));
 		LineCount++;
 	}
+	if(Lines.m_ShowSync)
+	{
+		MaxWidth = maximum(MaxWidth, pTextRender->TextWidth(Layout.m_FontSize, Lines.m_aSyncLine, -1, -1.0f));
+		LineCount++;
+	}
 
 	if(LineCount == 0)
 	{
@@ -2002,14 +2022,16 @@ SKeyStatusLayout GetKeyStatusLayout(ITextRender *pTextRender, const SKeyStatusLi
 
 	Layout.m_W = MaxWidth + Layout.m_PaddingX * 2.0f;
 	Layout.m_H = Layout.m_LineHeight * LineCount + Layout.m_PaddingY * 2.0f;
+	const float MaxX = maximum(HudWidth - Layout.m_W, 0.0f);
+	Layout.m_X = std::clamp(HudWidth - Layout.m_W - KEY_STATUS_RIGHT_MARGIN, 0.0f, MaxX);
 	return Layout;
 }
 }
 
 void CHud::RenderKeyStatus()
 {
-	const SKeyStatusLines Lines = GetKeyStatusLines(GameClient());
-	const SKeyStatusLayout Layout = GetKeyStatusLayout(TextRender(), Lines);
+	const SKeyStatusLines Lines = GetKeyStatusLines();
+	const SKeyStatusLayout Layout = GetKeyStatusLayout(TextRender(), Lines, m_Width);
 	if(Layout.m_H <= 0.0f)
 		return;
 
@@ -2037,6 +2059,11 @@ void CHud::RenderKeyStatus()
 	if(Lines.m_ShowControl)
 	{
 		TextRender()->Text(TextX, TextY, Layout.m_FontSize, Lines.m_aControlLine, -1.0f);
+		TextY += Layout.m_LineHeight;
+	}
+	if(Lines.m_ShowSync)
+	{
+		TextRender()->Text(TextX, TextY, Layout.m_FontSize, Lines.m_aSyncLine, -1.0f);
 	}
 	TextRender()->TextColor(TextRender()->DefaultTextColor());
 }
@@ -2169,8 +2196,8 @@ void CHud::RenderMovementInformation()
 	const float Fontsize = 6.0f;
 	const float KeyStatusGap = 2.0f;
 
-	const SKeyStatusLines KeyStatusLines = GetKeyStatusLines(GameClient());
-	const SKeyStatusLayout KeyStatusLayout = GetKeyStatusLayout(TextRender(), KeyStatusLines);
+	const SKeyStatusLines KeyStatusLines = GetKeyStatusLines();
+	const SKeyStatusLayout KeyStatusLayout = GetKeyStatusLayout(TextRender(), KeyStatusLines, m_Width);
 	const bool ShowKeyStatus = KeyStatusLayout.m_H > 0.0f;
 
 	float MovementBoxHeight = ShowMovementInfo ? GetMovementInformationBoxHeight() : 0.0f;
@@ -2262,16 +2289,14 @@ void CHud::RenderMovementInformation()
 		Client()->DummyConnected();
 	const float DummyActionsReserveY = ShowDummyActionsHud ? (29.0f + 4.0f) : 0.0f;
 
-	float StartX = KeyStatusLayout.m_X;
+	const float MaxStartX = maximum(0.0f, m_Width - BoxWidth);
+	float StartX = std::clamp(m_Width - BoxWidth - KEY_STATUS_RIGHT_MARGIN, 0.0f, MaxStartX);
 	float StartY = 285.0f - BoxHeight - 4.0f;
 	if(g_Config.m_ClShowhudScore)
 	{
 		StartY -= 56.0f;
 	}
 	StartY -= DummyActionsReserveY;
-	StartX = minimum(StartX, m_Width - BoxWidth);
-	if(StartX < 0.0f)
-		StartX = 0.0f;
 	if(StartY < 0.0f)
 		StartY = 0.0f;
 
@@ -2486,6 +2511,11 @@ void CHud::RenderMovementInformation()
 		if(KeyStatusLines.m_ShowControl)
 		{
 			TextRender()->Text(KeyTextX, KeyTextY, KeyStatusLayout.m_FontSize, KeyStatusLines.m_aControlLine, -1.0f);
+			KeyTextY += KeyStatusLayout.m_LineHeight;
+		}
+		if(KeyStatusLines.m_ShowSync)
+		{
+			TextRender()->Text(KeyTextX, KeyTextY, KeyStatusLayout.m_FontSize, KeyStatusLines.m_aSyncLine, -1.0f);
 		}
 		TextRender()->TextColor(TextRender()->DefaultTextColor());
 	}

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -231,6 +231,9 @@ int CMenus::DoButton_MenuTab(CButtonContainer *pButtonContainer, const char *pTe
 		}
 	}
 
+	// Keep tab contents inside the original button rect to avoid overlap on narrow layouts.
+	Ui()->ClipEnable(pRect);
+
 	if(pCommunityIcon)
 	{
 		CUIRect CommunityIcon;
@@ -243,6 +246,7 @@ int CMenus::DoButton_MenuTab(CButtonContainer *pButtonContainer, const char *pTe
 		Rect.HMargin(2.0f, &Label);
 		Ui()->DoLabel(&Label, pText, Label.h * CUi::ms_FontmodHeight, TEXTALIGN_MC);
 	}
+	Ui()->ClipDisable();
 
 	return Ui()->DoButtonLogic(pButtonContainer, Checked, pRect, BUTTONFLAG_LEFT);
 }
@@ -704,11 +708,6 @@ void CMenus::RenderMenubar(CUIRect Box, IClient::EClientState ClientState)
 			if(DoButton_MenuTab(&s_GhostButton, Localize("Ghost"), ActivePage == PAGE_GHOST, &Button, IGraphics::CORNER_NONE))
 				NewPage = PAGE_GHOST;
 		}
-
-		Box.VSplitLeft(110.0f, &Button, &Box);
-		static CButtonContainer s_UnfinishedMapsButton;
-		if(DoButton_MenuTab(&s_UnfinishedMapsButton, Localize("未完成图"), ActivePage == PAGE_UNFINISHED_MAPS, &Button, IGraphics::CORNER_NONE))
-			NewPage = PAGE_UNFINISHED_MAPS;
 
 		Box.VSplitLeft(100.0f, &Button, &Box);
 		Box.VSplitLeft(4.0f, nullptr, &Box);
@@ -2609,6 +2608,10 @@ void CMenus::SetMenuPage(int NewPage)
 
 void CMenus::SetGamePage(int NewPage)
 {
+	// "Unfinished maps" is no longer exposed in navigation.
+	if(NewPage == PAGE_UNFINISHED_MAPS)
+		NewPage = PAGE_GAME;
+
 	const int OldPage = m_GamePage;
 	m_GamePage = NewPage;
 	if(OldPage != NewPage)

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -2113,9 +2113,11 @@ void CMenus::RenderSettings(CUIRect MainView)
 
 	// render background
 	CUIRect Button, TabBar, RestartBar;
-	MainView.VSplitRight(120.0f, &MainView, &TabBar);
+	const float TabBarWidth = std::clamp(MainView.w * 0.14f, 108.0f, 120.0f);
+	MainView.VSplitRight(TabBarWidth, &MainView, &TabBar);
 	MainView.Draw(ms_ColorTabbarActive, IGraphics::CORNER_B, 10.0f);
-	MainView.Margin(20.0f, &MainView);
+	const float ContentMargin = std::clamp(MainView.w * 0.02f, 12.0f, 20.0f);
+	MainView.Margin(ContentMargin, &MainView);
 
 	const bool NeedRestart = m_NeedRestartGraphics || m_NeedRestartSound || m_NeedRestartUpdate;
 	if(NeedRestart)
@@ -2701,6 +2703,7 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 		DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClShowhudKeyStatusReset, Localize("显示卡键状态"), &g_Config.m_ClShowhudKeyStatusReset, &RightView, LineSize);
 		DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClShowhudKeyStatusHammer, Localize("显示锤状态"), &g_Config.m_ClShowhudKeyStatusHammer, &RightView, LineSize);
 		DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClShowhudKeyStatusControl, Localize("显示分身控制状态"), &g_Config.m_ClShowhudKeyStatusControl, &RightView, LineSize);
+		DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClShowhudKeyStatusSync, Localize("显示分身同步状态"), &g_Config.m_ClShowhudKeyStatusSync, &RightView, LineSize);
 
 		// Player movement information display settings
 		RightView.HSplitTop(MarginSmall, nullptr, &RightView); // TClient

--- a/src/game/client/components/menus_start.cpp
+++ b/src/game/client/components/menus_start.cpp
@@ -106,19 +106,6 @@ void CMenusStart::RenderStartMenu(CUIRect MainView)
 	if(GameClient()->m_Menus.DoButton_Menu(&s_NewsButton, Localize("News"), 0, &Button, BUTTONFLAG_LEFT, nullptr, IGraphics::CORNER_ALL, 5.0f, 0.0f, g_Config.m_UiUnreadNews ? ColorRGBA(0.0f, 1.0f, 0.0f, 0.25f) : ColorRGBA(0.0f, 0.0f, 0.0f, 0.25f)) || CheckHotKey(KEY_N))
 		NewPage = CMenus::PAGE_NEWS;
 
-	ExtMenu.HSplitBottom(5.0f, &ExtMenu, nullptr); // little space
-	ExtMenu.HSplitBottom(20.0f, &ExtMenu, &Button);
-	static CButtonContainer s_UpdateButton;
-	const bool UpdateChecking = GameClient()->m_TClient.IsUpdateChecking();
-	const bool UpdateDownloading = GameClient()->m_TClient.IsUpdateDownloading();
-	const bool UpdateBusy = UpdateChecking || UpdateDownloading;
-	const char *pUpdateLabel = UpdateDownloading ? Localize("Updating…") : (UpdateChecking ? Localize("Checking…") : Localize("Update"));
-	if(GameClient()->m_Menus.DoButton_Menu(&s_UpdateButton, pUpdateLabel, 0, &Button, BUTTONFLAG_LEFT, nullptr, IGraphics::CORNER_ALL, 5.0f, 0.0f, ColorRGBA(0.0f, 0.0f, 0.0f, 0.25f)))
-	{
-		if(!UpdateBusy)
-			GameClient()->m_TClient.RequestUpdateCheckAndUpdate();
-	}
-
 	CUIRect Menu;
 	MainView.VMargin(VMargin, &Menu);
 	CUIRect QuitNote;

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -1603,39 +1603,44 @@ void CPlayers::OnRender()
 	const bool IsTeamPlay = GameClient()->IsTeamPlay();
 	for(int i = 0; i < MAX_CLIENTS; ++i)
 	{
-		aRenderInfo[i] = GameClient()->m_aClients[i].m_RenderInfo;
+		const auto &ClientData = GameClient()->m_aClients[i];
+		aRenderInfo[i] = ClientData.m_RenderInfo;
 		aRenderInfo[i].m_TeeRenderFlags = 0;
 
 		// predict freeze skin only for local players
 		bool Frozen = false;
 		if(i == GameClient()->m_aLocalIds[0] || i == GameClient()->m_aLocalIds[1])
 		{
-			if(GameClient()->m_aClients[i].m_Predicted.m_FreezeEnd != 0)
+			const CCharacterCore &Predicted = ClientData.m_Predicted;
+			if(Predicted.m_FreezeEnd != 0)
 				aRenderInfo[i].m_TeeRenderFlags |= TEE_EFFECT_FROZEN | TEE_NO_WEAPON;
-			if(GameClient()->m_aClients[i].m_Predicted.m_LiveFrozen)
+			if(Predicted.m_LiveFrozen)
 				aRenderInfo[i].m_TeeRenderFlags |= TEE_EFFECT_FROZEN;
-			if(GameClient()->m_aClients[i].m_Predicted.m_Invincible)
+			if(Predicted.m_Invincible)
 				aRenderInfo[i].m_TeeRenderFlags |= TEE_EFFECT_SPARKLE;
 
-			Frozen = GameClient()->m_aClients[i].m_Predicted.m_FreezeEnd != 0;
+			Frozen = Predicted.m_FreezeEnd != 0 || Predicted.m_LiveFrozen || ClientData.m_IsInFreeze;
 			// TClient
-			if(g_Config.m_TcFastInput)
-				Frozen = GameClient()->m_aClients[i].m_RegularPredicted.m_FreezeEnd != 0;
+			if(g_Config.m_TcFastInput && GameClient()->Predict())
+			{
+				const CCharacterCore &RegularPredicted = ClientData.m_RegularPredicted;
+				Frozen = RegularPredicted.m_FreezeEnd != 0 || RegularPredicted.m_LiveFrozen || ClientData.m_IsInFreeze;
+			}
 		}
 		else
 		{
-			if(GameClient()->m_aClients[i].m_FreezeEnd != 0)
+			if(ClientData.m_FreezeEnd != 0)
 				aRenderInfo[i].m_TeeRenderFlags |= TEE_EFFECT_FROZEN | TEE_NO_WEAPON;
-			if(GameClient()->m_aClients[i].m_LiveFrozen)
+			if(ClientData.m_LiveFrozen)
 				aRenderInfo[i].m_TeeRenderFlags |= TEE_EFFECT_FROZEN;
-			if(GameClient()->m_aClients[i].m_Invincible)
+			if(ClientData.m_Invincible)
 				aRenderInfo[i].m_TeeRenderFlags |= TEE_EFFECT_SPARKLE;
 
-			Frozen = GameClient()->m_Snap.m_aCharacters[i].m_HasExtendedData && GameClient()->m_Snap.m_aCharacters[i].m_ExtendedData.m_FreezeEnd != 0;
+			Frozen = ClientData.m_FreezeEnd != 0 || ClientData.m_LiveFrozen || ClientData.m_IsInFreeze;
 		}
 
 		// TClient
-		if(g_Config.m_TcFreezeKatana > 0 && GameClient()->m_aClients[i].m_Predicted.m_FreezeEnd != 0)
+		if(g_Config.m_TcFreezeKatana > 0 && Frozen)
 		{
 			GameClient()->m_aClients[i].m_RenderCur.m_Weapon = WEAPON_NINJA;
 			aRenderInfo[i].m_TeeRenderFlags &= ~TEE_NO_WEAPON;

--- a/src/game/client/components/tclient/bg_draw.cpp
+++ b/src/game/client/components/tclient/bg_draw.cpp
@@ -365,6 +365,9 @@ static IOHANDLE BgDrawOpenFile(CGameClient &This, const char *pFilename, int Fla
 
 bool CBgDraw::Save(const char *pFilename, bool Verbose)
 {
+	if(Client()->State() != IClient::STATE_ONLINE && Client()->State() != IClient::STATE_DEMOPLAYBACK)
+		return false;
+
 	if(m_pvItems->size() == 0)
 	{
 		if(Verbose)

--- a/src/game/client/components/tclient/menus_qmclient.cpp
+++ b/src/game/client/components/tclient/menus_qmclient.cpp
@@ -34,6 +34,7 @@
 
 #include <algorithm>
 #include <array>
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -79,84 +80,148 @@ const float MarginBetweenViews = 30.0f;
 const float ColorPickerLabelSize = 13.0f;
 const float ColorPickerLineSpacing = 5.0f;
 
-static const char *s_apQiaFenPresetWords[] = {
-	"有人恰吗",
-	"有人要吗",
-	"有恰的吗",
-	"有人要分吗",
-	"有人恰分吗",
-	"有恰分的吗",
-	"有要分的吗",
+struct SAutoReplyRulePlain
+{
+	std::string m_Keywords;
+	std::string m_Reply;
 };
 
-static int QiaFenSeparatorLength(const char *pStr)
+struct SAutoReplyRuleInputRow
 {
-	const unsigned char C0 = (unsigned char)pStr[0];
-	if(C0 == ',' || C0 == ';' || C0 == '|' || C0 == '\n' || C0 == '\r')
-		return 1;
-	if(C0 == 0xEF && (unsigned char)pStr[1] == 0xBC)
-	{
-		const unsigned char C2 = (unsigned char)pStr[2];
-		if(C2 == 0x8C || C2 == 0x9B)
-			return 3;
-	}
-	return 0;
-}
+	char m_aTrigger[512] = "";
+	char m_aReply[256] = "";
+	CLineInput m_TriggerInput;
+	CLineInput m_ReplyInput;
 
-static bool IsQiaFenPresetWord(const char *pWord)
-{
-	for(const char *pPreset : s_apQiaFenPresetWords)
+	SAutoReplyRuleInputRow()
 	{
-		if(str_utf8_comp_nocase(pWord, pPreset) == 0)
-			return true;
+		m_TriggerInput.SetBuffer(m_aTrigger, sizeof(m_aTrigger));
+		m_ReplyInput.SetBuffer(m_aReply, sizeof(m_aReply));
 	}
-	return false;
-}
+};
 
-static bool FindQiaFenPresetDuplicate(const char *pKeywords, char *pOut, size_t OutSize)
+static bool CopyTrimmedString(const char *pSrc, char *pOut, size_t OutSize)
 {
-	if(!pKeywords || pKeywords[0] == '\0')
+	pOut[0] = '\0';
+	if(!pSrc)
 		return false;
 
-	char aBuf[512];
-	str_copy(aBuf, pKeywords, sizeof(aBuf));
-	char *pCursor = aBuf;
+	char aBuf[1024];
+	str_copy(aBuf, pSrc, sizeof(aBuf));
+	char *pTrimmed = (char *)str_utf8_skip_whitespaces(aBuf);
+	str_utf8_trim_right(pTrimmed);
+	str_copy(pOut, pTrimmed, OutSize);
+	return pOut[0] != '\0';
+}
 
+static std::unique_ptr<SAutoReplyRuleInputRow> CreateAutoReplyRuleInputRow(const char *pTrigger = "", const char *pReply = "")
+{
+	auto pRow = std::make_unique<SAutoReplyRuleInputRow>();
+	pRow->m_TriggerInput.Set(pTrigger);
+	pRow->m_ReplyInput.Set(pReply);
+	return pRow;
+}
+
+static void ParseAutoReplyRules(const char *pRules, std::vector<SAutoReplyRulePlain> &vOutRules)
+{
+	vOutRules.clear();
+	if(!pRules || pRules[0] == '\0')
+		return;
+
+	const char *pCursor = pRules;
 	while(*pCursor)
 	{
-		int SepLen = QiaFenSeparatorLength(pCursor);
-		while(*pCursor && SepLen > 0)
+		char aLine[1024];
+		int LineLen = 0;
+		while(*pCursor && *pCursor != '\n' && *pCursor != '\r')
 		{
-			pCursor += SepLen;
-			SepLen = QiaFenSeparatorLength(pCursor);
+			if(LineLen < (int)sizeof(aLine) - 1)
+				aLine[LineLen++] = *pCursor;
+			pCursor++;
 		}
+		aLine[LineLen] = '\0';
 
-		char *pStart = pCursor;
-		while(*pCursor && QiaFenSeparatorLength(pCursor) == 0)
+		while(*pCursor == '\n' || *pCursor == '\r')
 			pCursor++;
 
-		if(pStart == pCursor)
-			break;
-
-		if(*pCursor)
-		{
-			const int CutLen = QiaFenSeparatorLength(pCursor);
-			*pCursor = '\0';
-			pCursor += CutLen;
-		}
-
-		char *pToken = (char *)str_utf8_skip_whitespaces(pStart);
-		str_utf8_trim_right(pToken);
-		if(pToken[0] == '\0')
+		char *pLine = (char *)str_utf8_skip_whitespaces(aLine);
+		str_utf8_trim_right(pLine);
+		if(pLine[0] == '\0' || pLine[0] == '#')
 			continue;
-		if(IsQiaFenPresetWord(pToken))
-		{
-			str_copy(pOut, pToken, OutSize);
-			return true;
-		}
+
+		const char *pArrowConst = str_find(pLine, "=>");
+		if(!pArrowConst)
+			continue;
+
+		char *pArrow = pLine + (pArrowConst - pLine);
+		*pArrow = '\0';
+		pArrow += 2;
+
+		char *pKeywords = (char *)str_utf8_skip_whitespaces(pLine);
+		str_utf8_trim_right(pKeywords);
+		char *pReply = (char *)str_utf8_skip_whitespaces(pArrow);
+		str_utf8_trim_right(pReply);
+		if(pKeywords[0] == '\0' || pReply[0] == '\0')
+			continue;
+
+		vOutRules.push_back({pKeywords, pReply});
+	}
+}
+
+static bool AutoReplyRowsMatchRules(const std::vector<std::unique_ptr<SAutoReplyRuleInputRow>> &vRows, const std::vector<SAutoReplyRulePlain> &vRules)
+{
+	std::vector<SAutoReplyRulePlain> vCompleteRows;
+	vCompleteRows.reserve(vRows.size());
+	for(const auto &pRow : vRows)
+	{
+		char aTrigger[512];
+		char aReply[256];
+		const bool HasTrigger = CopyTrimmedString(pRow->m_TriggerInput.GetString(), aTrigger, sizeof(aTrigger));
+		const bool HasReply = CopyTrimmedString(pRow->m_ReplyInput.GetString(), aReply, sizeof(aReply));
+		if(!(HasTrigger && HasReply))
+			continue;
+		vCompleteRows.push_back({aTrigger, aReply});
 	}
 
-	return false;
+	if(vCompleteRows.size() != vRules.size())
+		return false;
+
+	for(size_t i = 0; i < vCompleteRows.size(); ++i)
+	{
+		if(str_comp(vCompleteRows[i].m_Keywords.c_str(), vRules[i].m_Keywords.c_str()) != 0 ||
+			str_comp(vCompleteRows[i].m_Reply.c_str(), vRules[i].m_Reply.c_str()) != 0)
+			return false;
+	}
+	return true;
+}
+
+static bool IsAutoReplyRuleRowHalfFilled(const SAutoReplyRuleInputRow &Row)
+{
+	char aTrigger[512];
+	char aReply[256];
+	const bool HasTrigger = CopyTrimmedString(Row.m_TriggerInput.GetString(), aTrigger, sizeof(aTrigger));
+	const bool HasReply = CopyTrimmedString(Row.m_ReplyInput.GetString(), aReply, sizeof(aReply));
+	return HasTrigger != HasReply;
+}
+
+static void BuildAutoReplyRulesFromRows(const std::vector<std::unique_ptr<SAutoReplyRuleInputRow>> &vRows, char *pOutRules, size_t OutRulesSize)
+{
+	pOutRules[0] = '\0';
+	for(const auto &pRow : vRows)
+	{
+		char aTrigger[512];
+		char aReply[256];
+		const bool HasTrigger = CopyTrimmedString(pRow->m_TriggerInput.GetString(), aTrigger, sizeof(aTrigger));
+		const bool HasReply = CopyTrimmedString(pRow->m_ReplyInput.GetString(), aReply, sizeof(aReply));
+		if(!(HasTrigger && HasReply))
+			continue;
+
+		if(pOutRules[0] != '\0')
+			str_append(pOutRules, "\n", OutRulesSize);
+		str_append(pOutRules, aTrigger, OutRulesSize);
+		str_append(pOutRules, "=>", OutRulesSize);
+		str_append(pOutRules, aReply, OutRulesSize);
+	}
 }
 
 static float CalcQiaFenInputHeight(ITextRender *pTextRender, const char *pText, float Width, float FontSize, float LineSpacing, float MinHeight)
@@ -1254,17 +1319,32 @@ void CMenus::RenderSettingsTClientSettings(CUIRect MainView)
 	Column.HSplitTop(MarginBetweenSections, nullptr, &Column);
 	s_SectionBoxes.push_back(Column);
 	Column.HSplitTop(HeadlineHeight, &Label, &Column);
-	Ui()->DoLabel(&Label, TCLocalize("Finish Name"), HeadlineFontSize, TEXTALIGN_ML);
+	Ui()->DoLabel(&Label, TCLocalize("终点前改名"), HeadlineFontSize, TEXTALIGN_ML);
 	Column.HSplitTop(MarginSmall, nullptr, &Column);
 
-	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_TcChangeNameNearFinish, TCLocalize("Attempt to change your name when near finish"), &g_Config.m_TcChangeNameNearFinish, &Column, LineSize);
+	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_TcChangeNameNearFinish, TCLocalize("过终点前尝试改名"), &g_Config.m_TcChangeNameNearFinish, &Column, LineSize);
+	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_TcFinishNameRequireOwnFinished, TCLocalize("如果自己没过就不改名"), &g_Config.m_TcFinishNameRequireOwnFinished, &Column, LineSize);
 	Column.HSplitTop(LineSize, &Button, &Column);
-	//Ui()->DoScrollbarOption(&g_Config.m_TcPetSize, &g_Config.m_TcPetSize, &Button, TCLocalize("Pet size"), 10, 500, &CUi::ms_LinearScrollbarScale, 0, "%");
-	//Column.HSplitTop(LineSize + MarginExtraSmall, &Button, &Column);
+
+	// One-time migration from legacy single-name config to unified queue config.
+	static bool s_FinishNameQueueMigrated = false;
+	if(!s_FinishNameQueueMigrated)
+	{
+		if(g_Config.m_TcFinishNameQueue[0] == '\0' && g_Config.m_TcFinishName[0] != '\0')
+		{
+			str_copy(g_Config.m_TcFinishNameQueue, g_Config.m_TcFinishName, sizeof(g_Config.m_TcFinishNameQueue));
+			g_Config.m_TcFinishName[0] = '\0';
+		}
+		s_FinishNameQueueMigrated = true;
+	}
+
 	Button.VSplitMid(&Label, &Button);
-	Ui()->DoLabel(&Label, TCLocalize("Finish Name:"), FontSize, TEXTALIGN_ML);
-	static CLineInput s_FinishName(g_Config.m_TcFinishName, sizeof(g_Config.m_TcFinishName));
-	Ui()->DoEditBox(&s_FinishName, &Button, EditBoxFontSize);
+	Ui()->DoLabel(&Label, TCLocalize("改名队列："), FontSize, TEXTALIGN_ML);
+	static CLineInput s_FinishNameQueueInput(g_Config.m_TcFinishNameQueue, sizeof(g_Config.m_TcFinishNameQueue));
+	Ui()->DoEditBox(&s_FinishNameQueueInput, &Button, EditBoxFontSize);
+
+	Column.HSplitTop(LineSize, &Label, &Column);
+	Ui()->DoLabel(&Label, TCLocalize("支持单名字或队列，多个名字用 | 分隔（按顺序）"), FontSize, TEXTALIGN_ML);
 	s_SectionBoxes.back().h = Column.y - s_SectionBoxes.back().y;
 
 
@@ -3130,8 +3210,9 @@ void CMenus::RenderSettingsQiMeng(CUIRect MainView)
 
 	// === 布局常量（统一定义，禁止魔数） ===
 	const float ViewWidth = MainView.w;
-	const float UiScale = std::clamp(ViewWidth / 1000.0f, 0.85f, 1.0f);
-	const bool CompactLayout = ViewWidth < 600.0f;
+	// 5:4 等窄屏在设置页实际可用宽度会明显变小，提前切紧凑布局并适当缩放。
+	const bool CompactLayout = ViewWidth < 680.0f;
+	const float UiScale = std::clamp(ViewWidth / 1000.0f, CompactLayout ? 0.78f : 0.85f, 1.0f);
 
 	const float LG_CardPadding = std::clamp(14.0f * UiScale, 10.0f, 14.0f);          // 卡片内边距
 	const float LG_CardSpacing = std::clamp(16.0f * UiScale, 10.0f, 16.0f);          // 卡片间距
@@ -3144,8 +3225,10 @@ void CMenus::RenderSettingsQiMeng(CUIRect MainView)
 	const float LG_HeadlineMargin = std::clamp(10.0f * UiScale, 7.0f, 10.0f);        // 标题下方间距
 	const float LG_TipSize = std::clamp(LG_BodySize * 0.7f, 8.0f, LG_BodySize);
 	const float LG_TipHeight = maximum(LG_HeadlineMargin, LG_TipSize + 2.0f);
-	const float LG_LabelMaxWidth = maximum(120.0f, ViewWidth * 0.45f);
-	const float LG_LabelWidth = std::clamp(170.0f * UiScale, 120.0f, LG_LabelMaxWidth); // 左侧标签列宽度（固定）
+	const float LG_LabelMaxWidth = maximum(CompactLayout ? 96.0f : 120.0f, ViewWidth * (CompactLayout ? 0.38f : 0.45f));
+	const float LG_LabelBaseWidth = CompactLayout ? 148.0f : 170.0f;
+	const float LG_LabelMinWidth = CompactLayout ? 96.0f : 120.0f;
+	const float LG_LabelWidth = std::clamp(LG_LabelBaseWidth * UiScale, LG_LabelMinWidth, LG_LabelMaxWidth); // 左侧标签列宽度（固定）
 
 	// === 颜色定义 ===
 	const ColorRGBA LG_GlassColor(0.08f, 0.09f, 0.12f, LG_CardAlpha);
@@ -3169,7 +3252,7 @@ void CMenus::RenderSettingsQiMeng(CUIRect MainView)
 	MainView.y += ScrollOffset.y;
 
 	// 外边距
-	const float OuterMargin = std::clamp(10.0f * UiScale, 6.0f, 10.0f);
+	const float OuterMargin = CompactLayout ? std::clamp(7.0f * UiScale, 4.0f, 7.0f) : std::clamp(10.0f * UiScale, 6.0f, 10.0f);
 	MainView.VSplitRight(OuterMargin, &MainView, nullptr);
 	MainView.VSplitLeft(OuterMargin, nullptr, &MainView);
 
@@ -3222,6 +3305,18 @@ void CMenus::RenderSettingsQiMeng(CUIRect MainView)
 			Ui()->DoLabel(&TipRect, pTip, LG_TipSize, TEXTALIGN_ML);
 			TextRender()->TextColor(TextRender()->DefaultTextColor());
 		}
+	};
+	auto RenderMenuImage = [&](const CMenuImage *pImage, const CUIRect &Rect, float Alpha = 1.0f) {
+		if(!pImage)
+			return;
+		Graphics()->TextureSet(pImage->m_OrgTexture);
+		Graphics()->WrapClamp();
+		Graphics()->QuadsBegin();
+		Graphics()->SetColor(1.0f, 1.0f, 1.0f, Alpha);
+		IGraphics::CQuadItem QuadItem(Rect.x, Rect.y, Rect.w, Rect.h);
+		Graphics()->QuadsDrawTL(&QuadItem, 1);
+		Graphics()->QuadsEnd();
+		Graphics()->WrapNormal();
 	};
 
 	CUIRect Row, LabelCol, ControlCol, CardContent;
@@ -3714,6 +3809,15 @@ void CMenus::RenderSettingsQiMeng(CUIRect MainView)
 			}
 			LeftContent.HSplitTop(LG_LineSpacing * 2, nullptr, &LeftContent);
 			DoModuleHeadline(LeftContent, -3, TCLocalize("赞助"), TCLocalize("感谢您为QmClient做出的贡献"));
+			if(const CMenuImage *pSponsorImage = FindMenuImage("sponsor"))
+			{
+				const float SponsorImageHeight = std::clamp(LeftContent.w * 0.30f, LG_LineHeight * 2.2f, LG_LineHeight * 4.2f);
+				LeftContent.HSplitTop(SponsorImageHeight, &Row, &LeftContent);
+				CUIRect SponsorImageRect = Row;
+				SponsorImageRect.Margin(LG_LineSpacing * 0.4f, &SponsorImageRect);
+				RenderMenuImage(pSponsorImage, SponsorImageRect, 1.0f);
+				LeftContent.HSplitTop(LG_LineSpacing, nullptr, &LeftContent);
+			}
 			LeftContent.HSplitTop(LG_LineHeight, &Row, &LeftContent);
 			{
 				CUIRect SponsorButton;
@@ -3792,8 +3896,11 @@ void CMenus::RenderSettingsQiMeng(CUIRect MainView)
 					"鹑",
 					"枫香°",
 					"爱发电用户_07470",
-					"蓝蓝蓝蓝",
-					"临渊织网"
+					"·蓝蓝蓝蓝",
+					"临渊捕鱼",
+					"?hook?",
+					"放肆zero",
+					"Q币"
 				};
 				const float SponsorFontSize = LG_BodySize * 1.1f;
 				const float MaxLineWidth = RightContent.w;
@@ -4113,6 +4220,10 @@ void CMenus::RenderSettingsQiMeng(CUIRect MainView)
 				CardContent.HSplitTop(LG_LineSpacing, nullptr, &CardContent);
 
 				CardContent.HSplitTop(LG_LineHeight, &Row, &CardContent);
+				DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_QmRepeatAutoAddOne, TCLocalize("自动加一"), &g_Config.m_QmRepeatAutoAddOne, &Row, LG_LineHeight);
+				CardContent.HSplitTop(LG_LineSpacing, nullptr, &CardContent);
+
+				CardContent.HSplitTop(LG_LineHeight, &Row, &CardContent);
 				DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_QmHammerSwapSkin, TCLocalize("锤人换皮肤"), &g_Config.m_QmHammerSwapSkin, &Row, LG_LineHeight);
 				CardContent.HSplitTop(LG_LineSpacing, nullptr, &CardContent);
 
@@ -4247,6 +4358,21 @@ void CMenus::RenderSettingsQiMeng(CUIRect MainView)
 					CardContent.HSplitTop(LG_LineSpacing, nullptr, &CardContent);
 				}
 
+				CardContent.HSplitTop(LG_LineHeight, &Row, &CardContent);
+				DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_QmFriendEnterAutoGreet, TCLocalize("好友进图自动打招呼"), &g_Config.m_QmFriendEnterAutoGreet, &Row, LG_LineHeight);
+				CardContent.HSplitTop(LG_LineSpacing, nullptr, &CardContent);
+
+				if(g_Config.m_QmFriendEnterAutoGreet)
+				{
+					CardContent.HSplitTop(LG_LineHeight, &Row, &CardContent);
+					Row.VSplitLeft(LG_LabelWidth, &LabelCol, &ControlCol);
+					Ui()->DoLabel(&LabelCol, TCLocalize("打招呼文本"), LG_BodySize, TEXTALIGN_ML);
+					static CLineInput s_FriendEnterGreetText(g_Config.m_QmFriendEnterGreetText, sizeof(g_Config.m_QmFriendEnterGreetText));
+					s_FriendEnterGreetText.SetEmptyText(TCLocalize("留空禁用"));
+					Ui()->DoEditBox(&s_FriendEnterGreetText, &ControlCol, LG_BodySize);
+					CardContent.HSplitTop(LG_LineSpacing, nullptr, &CardContent);
+				}
+
 				CardContent.HSplitTop(LG_CardPadding, nullptr, &CardContent);
 				Column.y = CardContent.y;
 				s_GlassCards.back().h = Column.y - s_GlassCards.back().y;
@@ -4363,57 +4489,192 @@ void CMenus::RenderSettingsQiMeng(CUIRect MainView)
 				Column.HSplitTop(LG_CardPadding, nullptr, &Column);
 				Column.VSplitLeft(LG_CardPadding, nullptr, &CardContent);
 				CardContent.VSplitRight(LG_CardPadding, &CardContent, nullptr);
-				DoModuleHeadline(CardContent, 8, TCLocalize("恰分"), TCLocalize("自动识别并恰分"));
+				DoModuleHeadline(CardContent, 8, TCLocalize("恰分"), TCLocalize("恰分与关键词自动回复"));
+
+				CardContent.HSplitTop(LG_LineHeight, &Row, &CardContent);
+				Ui()->DoScrollbarOption(&g_Config.m_QmAutoReplyCooldown, &g_Config.m_QmAutoReplyCooldown, &Row, TCLocalize("自动回复冷却"), 0, 30, &CUi::ms_LinearScrollbarScale, 0, TCLocalize(" 秒"));
+				CardContent.HSplitTop(LG_LineSpacing, nullptr, &CardContent);
+
 				CardContent.HSplitTop(LG_LineHeight, &Row, &CardContent);
 				DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_QmQiaFenEnabled, TCLocalize("启用恰分功能"), &g_Config.m_QmQiaFenEnabled, &Row, LG_LineHeight);
 				CardContent.HSplitTop(LG_LineSpacing, nullptr, &CardContent);
+
 				CardContent.HSplitTop(LG_LineHeight, &Row, &CardContent);
-				DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_QmQiaFenUseDummy, TCLocalize("使用Dummy发言"), &g_Config.m_QmQiaFenUseDummy, &Row, LG_LineHeight);
-				CardContent.HSplitTop(LG_LineSpacing, nullptr, &CardContent);
-				CardContent.HSplitTop(LG_LineHeight * 0.8f, &Row, &CardContent);
-				TextRender()->TextColor(ColorRGBA(0.7f, 0.7f, 0.7f, 1.0f));
-				Ui()->DoLabel(&Row, TCLocalize("已通关的地图不会触发"), LG_BodySize * 0.7f, TEXTALIGN_ML);
-				TextRender()->TextColor(TextRender()->DefaultTextColor());
+				DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_QmQiaFenUseDummy, TCLocalize("恰分使用Dummy发言"), &g_Config.m_QmQiaFenUseDummy, &Row, LG_LineHeight);
 				CardContent.HSplitTop(LG_LineSpacing, nullptr, &CardContent);
 
-				static CLineInputBuffered<512> s_QiaFenKeywordsInput;
-				static bool s_QiaFenKeywordsInited = false;
-				static char s_aQiaFenKeywordsDuplicate[64] = "";
-				if(!s_QiaFenKeywordsInited)
-				{
-					s_QiaFenKeywordsInput.Set(g_Config.m_QmQiaFenKeywords);
-					s_QiaFenKeywordsInited = true;
-				}
-				else if(!s_QiaFenKeywordsInput.IsActive())
-				{
-					char aDuplicateCheck[64];
-					const bool HasDuplicate = FindQiaFenPresetDuplicate(s_QiaFenKeywordsInput.GetString(), aDuplicateCheck, sizeof(aDuplicateCheck));
-					if(!HasDuplicate && str_comp(s_QiaFenKeywordsInput.GetString(), g_Config.m_QmQiaFenKeywords) != 0)
-						s_QiaFenKeywordsInput.Set(g_Config.m_QmQiaFenKeywords);
-				}
-				s_QiaFenKeywordsInput.SetEmptyText(TCLocalize("用 , 分隔"));
+				auto SyncRuleRowsFromConfig = [](std::vector<std::unique_ptr<SAutoReplyRuleInputRow>> &vRows, bool &Inited, const char *pConfigRules) {
+					std::vector<SAutoReplyRulePlain> vParsedRules;
+					ParseAutoReplyRules(pConfigRules, vParsedRules);
 
-				const float InputWidth = CardContent.w - LG_LabelWidth;
-				const float InputLineSpacing = std::clamp(2.0f * UiScale, 1.0f, 2.0f);
-				const float InputHeight = CalcQiaFenInputHeight(TextRender(), s_QiaFenKeywordsInput.GetString(), InputWidth, LG_BodySize, InputLineSpacing, LG_LineHeight);
-				CardContent.HSplitTop(InputHeight, &Row, &CardContent);
+					const auto RebuildRows = [&]() {
+						vRows.clear();
+						for(const auto &Rule : vParsedRules)
+							vRows.push_back(CreateAutoReplyRuleInputRow(Rule.m_Keywords.c_str(), Rule.m_Reply.c_str()));
+					};
+
+					bool HasActiveInput = false;
+					for(const auto &pRow : vRows)
+					{
+						if(pRow->m_TriggerInput.IsActive() || pRow->m_ReplyInput.IsActive())
+						{
+							HasActiveInput = true;
+							break;
+						}
+					}
+
+					if(!Inited)
+					{
+						RebuildRows();
+						Inited = true;
+					}
+					else if(!HasActiveInput && !AutoReplyRowsMatchRules(vRows, vParsedRules))
+					{
+						RebuildRows();
+					}
+				};
+
+				static std::vector<std::unique_ptr<SAutoReplyRuleInputRow>> s_vQiaFenRuleRows;
+				static bool s_QiaFenRuleRowsInited = false;
+				static CButtonContainer s_QiaFenAddRuleButton;
+				static std::vector<CButtonContainer> s_vQiaFenRemoveRuleButtons;
+				SyncRuleRowsFromConfig(s_vQiaFenRuleRows, s_QiaFenRuleRowsInited, g_Config.m_QmQiaFenRules);
+
+				CardContent.HSplitTop(LG_LineHeight, &Row, &CardContent);
 				Row.VSplitLeft(LG_LabelWidth, &LabelCol, &ControlCol);
-				Ui()->DoLabel(&LabelCol, TCLocalize("识别词"), LG_BodySize, TEXTALIGN_ML);
-				const bool KeywordsChanged = DoEditBoxMultiLine(Ui(), &s_QiaFenKeywordsInput, &ControlCol, LG_BodySize, InputLineSpacing);
-
-				const bool HasDuplicate = FindQiaFenPresetDuplicate(s_QiaFenKeywordsInput.GetString(), s_aQiaFenKeywordsDuplicate, sizeof(s_aQiaFenKeywordsDuplicate));
-				if(!HasDuplicate && KeywordsChanged)
-					str_copy(g_Config.m_QmQiaFenKeywords, s_QiaFenKeywordsInput.GetString(), sizeof(g_Config.m_QmQiaFenKeywords));
-
-				if(HasDuplicate)
+				Ui()->DoLabel(&LabelCol, TCLocalize("恰分规则"), LG_BodySize, TEXTALIGN_ML);
+				CUIRect AddRuleButtonRect;
+				ControlCol.VSplitRight(maximum(LG_LineHeight, 24.0f * UiScale), &ControlCol, &AddRuleButtonRect);
+				if(DoButton_Menu(&s_QiaFenAddRuleButton, "+", 0, &AddRuleButtonRect))
 				{
-					CardContent.HSplitTop(LG_LineSpacing, nullptr, &CardContent);
+					auto pNewRule = CreateAutoReplyRuleInputRow();
+					pNewRule->m_TriggerInput.Activate(EInputPriority::UI);
+					s_vQiaFenRuleRows.push_back(std::move(pNewRule));
+				}
+				s_vQiaFenRemoveRuleButtons.resize(s_vQiaFenRuleRows.size());
+				CardContent.HSplitTop(LG_LineSpacing, nullptr, &CardContent);
+
+				for(size_t i = 0; i < s_vQiaFenRuleRows.size();)
+				{
+					auto &pRuleRow = s_vQiaFenRuleRows[i];
+					pRuleRow->m_TriggerInput.SetEmptyText("");
+					pRuleRow->m_ReplyInput.SetEmptyText("");
 					CardContent.HSplitTop(LG_LineHeight, &Row, &CardContent);
-					char aWarn[96];
-					str_format(aWarn, sizeof(aWarn), "%s已有", s_aQiaFenKeywordsDuplicate);
+					Row.VSplitLeft(LG_LabelWidth, nullptr, &ControlCol);
+					CUIRect TriggerCol, SendCol, ReplyCol, RemoveButtonRect;
+					ControlCol.VSplitRight(maximum(LG_LineHeight, 24.0f * UiScale), &ControlCol, &RemoveButtonRect);
+					ControlCol.VSplitLeft(ControlCol.w * 0.45f, &TriggerCol, &ControlCol);
+					ControlCol.VSplitLeft(maximum(40.0f, 40.0f * UiScale), &SendCol, &ReplyCol);
+					Ui()->DoEditBox(&pRuleRow->m_TriggerInput, &TriggerCol, LG_BodySize);
+					Ui()->DoLabel(&SendCol, TCLocalize("发送"), LG_BodySize, TEXTALIGN_MC);
+					Ui()->DoEditBox(&pRuleRow->m_ReplyInput, &ReplyCol, LG_BodySize);
+					const bool RemoveClicked = DoButton_Menu(&s_vQiaFenRemoveRuleButtons[i], "-", 0, &RemoveButtonRect);
+					CardContent.HSplitTop(LG_LineSpacing, nullptr, &CardContent);
+
+					if(RemoveClicked)
+					{
+						s_vQiaFenRuleRows.erase(s_vQiaFenRuleRows.begin() + i);
+						s_vQiaFenRemoveRuleButtons.erase(s_vQiaFenRemoveRuleButtons.begin() + i);
+						continue;
+					}
+					++i;
+				}
+
+				char aQiaFenRules[sizeof(g_Config.m_QmQiaFenRules)];
+				BuildAutoReplyRulesFromRows(s_vQiaFenRuleRows, aQiaFenRules, sizeof(aQiaFenRules));
+				str_copy(g_Config.m_QmQiaFenRules, aQiaFenRules, sizeof(g_Config.m_QmQiaFenRules));
+
+				bool QiaFenHalfFilled = false;
+				for(const auto &pRuleRow : s_vQiaFenRuleRows)
+				{
+					if(IsAutoReplyRuleRowHalfFilled(*pRuleRow))
+					{
+						QiaFenHalfFilled = true;
+						break;
+					}
+				}
+				if(QiaFenHalfFilled)
+				{
+					CardContent.HSplitTop(LG_LineHeight * 0.8f, &Row, &CardContent);
 					TextRender()->TextColor(1.0f, 0.2f, 0.2f, 1.0f);
-					Ui()->DoLabel(&Row, aWarn, LG_BodySize, TEXTALIGN_ML);
+					Ui()->DoLabel(&Row, TCLocalize("恰分规则两侧都需要填写"), LG_BodySize * 0.7f, TEXTALIGN_ML);
 					TextRender()->TextColor(TextRender()->DefaultTextColor());
+					CardContent.HSplitTop(LG_LineSpacing, nullptr, &CardContent);
+				}
+
+				CardContent.HSplitTop(LG_CardPadding * 0.7f, nullptr, &CardContent);
+				CardContent.HSplitTop(LG_LineHeight, &Row, &CardContent);
+				DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_QmKeywordReplyEnabled, TCLocalize("启用关键词回复"), &g_Config.m_QmKeywordReplyEnabled, &Row, LG_LineHeight);
+				CardContent.HSplitTop(LG_LineSpacing, nullptr, &CardContent);
+				CardContent.HSplitTop(LG_LineHeight, &Row, &CardContent);
+				DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_QmKeywordReplyUseDummy, TCLocalize("关键词回复使用Dummy"), &g_Config.m_QmKeywordReplyUseDummy, &Row, LG_LineHeight);
+				CardContent.HSplitTop(LG_LineSpacing, nullptr, &CardContent);
+
+				static std::vector<std::unique_ptr<SAutoReplyRuleInputRow>> s_vKeywordRuleRows;
+				static bool s_KeywordRuleRowsInited = false;
+				static CButtonContainer s_KeywordAddRuleButton;
+				static std::vector<CButtonContainer> s_vKeywordRemoveRuleButtons;
+				SyncRuleRowsFromConfig(s_vKeywordRuleRows, s_KeywordRuleRowsInited, g_Config.m_QmKeywordReplyRules);
+
+				CardContent.HSplitTop(LG_LineHeight, &Row, &CardContent);
+				Row.VSplitLeft(LG_LabelWidth, &LabelCol, &ControlCol);
+				Ui()->DoLabel(&LabelCol, TCLocalize("关键词规则"), LG_BodySize, TEXTALIGN_ML);
+				ControlCol.VSplitRight(maximum(LG_LineHeight, 24.0f * UiScale), &ControlCol, &AddRuleButtonRect);
+				if(DoButton_Menu(&s_KeywordAddRuleButton, "+", 0, &AddRuleButtonRect))
+				{
+					auto pNewRule = CreateAutoReplyRuleInputRow();
+					pNewRule->m_TriggerInput.Activate(EInputPriority::UI);
+					s_vKeywordRuleRows.push_back(std::move(pNewRule));
+				}
+				s_vKeywordRemoveRuleButtons.resize(s_vKeywordRuleRows.size());
+				CardContent.HSplitTop(LG_LineSpacing, nullptr, &CardContent);
+
+				for(size_t i = 0; i < s_vKeywordRuleRows.size();)
+				{
+					auto &pRuleRow = s_vKeywordRuleRows[i];
+					pRuleRow->m_TriggerInput.SetEmptyText("");
+					pRuleRow->m_ReplyInput.SetEmptyText("");
+					CardContent.HSplitTop(LG_LineHeight, &Row, &CardContent);
+					Row.VSplitLeft(LG_LabelWidth, nullptr, &ControlCol);
+					CUIRect TriggerCol, SendCol, ReplyCol, RemoveButtonRect;
+					ControlCol.VSplitRight(maximum(LG_LineHeight, 24.0f * UiScale), &ControlCol, &RemoveButtonRect);
+					ControlCol.VSplitLeft(ControlCol.w * 0.45f, &TriggerCol, &ControlCol);
+					ControlCol.VSplitLeft(maximum(40.0f, 40.0f * UiScale), &SendCol, &ReplyCol);
+					Ui()->DoEditBox(&pRuleRow->m_TriggerInput, &TriggerCol, LG_BodySize);
+					Ui()->DoLabel(&SendCol, TCLocalize("发送"), LG_BodySize, TEXTALIGN_MC);
+					Ui()->DoEditBox(&pRuleRow->m_ReplyInput, &ReplyCol, LG_BodySize);
+					const bool RemoveClicked = DoButton_Menu(&s_vKeywordRemoveRuleButtons[i], "-", 0, &RemoveButtonRect);
+					CardContent.HSplitTop(LG_LineSpacing, nullptr, &CardContent);
+
+					if(RemoveClicked)
+					{
+						s_vKeywordRuleRows.erase(s_vKeywordRuleRows.begin() + i);
+						s_vKeywordRemoveRuleButtons.erase(s_vKeywordRemoveRuleButtons.begin() + i);
+						continue;
+					}
+					++i;
+				}
+
+				char aKeywordRules[sizeof(g_Config.m_QmKeywordReplyRules)];
+				BuildAutoReplyRulesFromRows(s_vKeywordRuleRows, aKeywordRules, sizeof(aKeywordRules));
+				str_copy(g_Config.m_QmKeywordReplyRules, aKeywordRules, sizeof(g_Config.m_QmKeywordReplyRules));
+
+				bool KeywordHalfFilled = false;
+				for(const auto &pRuleRow : s_vKeywordRuleRows)
+				{
+					if(IsAutoReplyRuleRowHalfFilled(*pRuleRow))
+					{
+						KeywordHalfFilled = true;
+						break;
+					}
+				}
+				if(KeywordHalfFilled)
+				{
+					CardContent.HSplitTop(LG_LineHeight * 0.8f, &Row, &CardContent);
+					TextRender()->TextColor(1.0f, 0.2f, 0.2f, 1.0f);
+					Ui()->DoLabel(&Row, TCLocalize("关键词规则两侧都需要填写"), LG_BodySize * 0.7f, TEXTALIGN_ML);
+					TextRender()->TextColor(TextRender()->DefaultTextColor());
+					CardContent.HSplitTop(LG_LineSpacing, nullptr, &CardContent);
 				}
 
 				CardContent.HSplitTop(LG_CardPadding, nullptr, &CardContent);

--- a/src/game/client/components/tclient/tclient.cpp
+++ b/src/game/client/components/tclient/tclient.cpp
@@ -30,6 +30,8 @@
 #include <game/localization.h>
 #include <game/version.h>
 
+#include <vector>
+
 static constexpr const char *TCLIENT_INFO_URL = "https://raw.githubusercontent.com/wxj881027/Q1menG_Client/master/docs/info.json";
 static constexpr const char *TCLIENT_UPDATE_EXE_URL = "https://github.com/wxj881027/Q1menG_Client/releases/latest/download/DDNet.exe";
 static constexpr const char *MAP_CATEGORY_CACHE_FILE = "tclient/map_categories.json";
@@ -38,6 +40,13 @@ static constexpr int QMCLIENT_SYNC_INTERVAL_SECONDS = 30;
 static constexpr const char *QMCLIENT_TOKEN_URL = "http://42.194.185.210:8080/token";
 static constexpr const char *QMCLIENT_REPORT_URL = "http://42.194.185.210:8080/report";
 static constexpr const char *QMCLIENT_USERS_URL = "http://42.194.185.210:8080/users.json";
+static constexpr const char *s_pQiaFenDefaultReply = "我要恰!!谢谢佬!!!!";
+static constexpr const char *FINISH_STATUS_URL = "https://info.ddnet.org/info";
+static constexpr int64_t FINISH_STATUS_RETRY_DELAY_SECONDS = 3;
+static constexpr const char *s_pFinishStatusPendingEcho = "请等一下!还没查到恰分结果!!";
+
+static int QiaFenSeparatorLength(const char *pStr);
+static void ConvertLegacyQiaFenKeywordsToRules(const char *pKeywords, char *pOutRules, size_t OutRulesSize);
 
 static const json_value *JsonObjectField(const json_value *pObject, const char *pName)
 {
@@ -139,6 +148,16 @@ void CTClient::OnInit()
 		Client()->AddWarning(Warning);
 	}
 	LoadMapCategoryCache();
+
+	// 兼容旧版恰分关键词配置：首次升级时将“关键词列表”迁移为“关键词=>回复”规则。
+	if(g_Config.m_QmQiaFenRules[0] == '\0' && g_Config.m_QmQiaFenKeywords[0] != '\0')
+	{
+		char aRules[sizeof(g_Config.m_QmQiaFenRules)];
+		ConvertLegacyQiaFenKeywordsToRules(g_Config.m_QmQiaFenKeywords, aRules, sizeof(aRules));
+
+		if(aRules[0] != '\0')
+			str_copy(g_Config.m_QmQiaFenRules, aRules, sizeof(g_Config.m_QmQiaFenRules));
+	}
 }
 
 static bool LineShouldHighlight(const char *pLine, const char *pName)
@@ -188,6 +207,112 @@ static int QiaFenSeparatorLength(const char *pStr)
 	return 0;
 }
 
+static bool JsonArrayContainsString(const json_value *pArray, const char *pValue)
+{
+	if(!pArray || pArray->type != json_array || !pValue || pValue[0] == '\0')
+		return false;
+	for(unsigned i = 0; i < pArray->u.array.length; ++i)
+	{
+		const json_value &Entry = (*pArray)[i];
+		if(Entry.type != json_string)
+			continue;
+		if(str_comp((const char *)Entry, pValue) == 0)
+			return true;
+	}
+	return false;
+}
+
+static void ParseFinishNameQueue(const char *pQueue, std::vector<std::string> &vNames)
+{
+	vNames.clear();
+	if(!pQueue || pQueue[0] == '\0')
+		return;
+
+	char aQueue[512];
+	str_copy(aQueue, pQueue, sizeof(aQueue));
+	char *pCursor = aQueue;
+	while(*pCursor)
+	{
+		int SepLen = QiaFenSeparatorLength(pCursor);
+		while(*pCursor && SepLen > 0)
+		{
+			pCursor += SepLen;
+			SepLen = QiaFenSeparatorLength(pCursor);
+		}
+
+		char *pStart = pCursor;
+		while(*pCursor && QiaFenSeparatorLength(pCursor) == 0)
+			pCursor++;
+
+		if(pStart == pCursor)
+			break;
+
+		if(*pCursor)
+		{
+			const int CutLen = QiaFenSeparatorLength(pCursor);
+			*pCursor = '\0';
+			pCursor += CutLen;
+		}
+
+		char *pName = (char *)str_utf8_skip_whitespaces(pStart);
+		str_utf8_trim_right(pName);
+		if(pName[0] == '\0')
+			continue;
+
+		char aTrimmedName[MAX_NAME_LENGTH];
+		str_copy(aTrimmedName, pName, sizeof(aTrimmedName));
+		if(aTrimmedName[0] == '\0')
+			continue;
+		vNames.emplace_back(aTrimmedName);
+	}
+}
+
+static void ConvertLegacyQiaFenKeywordsToRules(const char *pKeywords, char *pOutRules, size_t OutRulesSize)
+{
+	pOutRules[0] = '\0';
+	if(!pKeywords || pKeywords[0] == '\0')
+		return;
+
+	char aLegacyKeywords[512];
+	str_copy(aLegacyKeywords, pKeywords, sizeof(aLegacyKeywords));
+	char *pCursor = aLegacyKeywords;
+
+	while(*pCursor)
+	{
+		int SepLen = QiaFenSeparatorLength(pCursor);
+		while(*pCursor && SepLen > 0)
+		{
+			pCursor += SepLen;
+			SepLen = QiaFenSeparatorLength(pCursor);
+		}
+
+		char *pStart = pCursor;
+		while(*pCursor && QiaFenSeparatorLength(pCursor) == 0)
+			pCursor++;
+
+		if(pStart == pCursor)
+			break;
+
+		if(*pCursor)
+		{
+			const int CutLen = QiaFenSeparatorLength(pCursor);
+			*pCursor = '\0';
+			pCursor += CutLen;
+		}
+
+		char *pKeyword = (char *)str_utf8_skip_whitespaces(pStart);
+		str_utf8_trim_right(pKeyword);
+		if(pKeyword[0] == '\0')
+			continue;
+
+		if(pOutRules[0] != '\0')
+			str_append(pOutRules, "\n", OutRulesSize);
+		str_append(pOutRules, pKeyword, OutRulesSize);
+		str_append(pOutRules, "=>", OutRulesSize);
+		str_append(pOutRules, s_pQiaFenDefaultReply, OutRulesSize);
+	}
+}
+
 static bool IsQiaFenPresetWord(const char *pWord)
 {
 	for(const char *pPreset : s_apQiaFenPresetWords)
@@ -202,13 +327,13 @@ static bool MessageMatchesQiaFenPreset(const char *pMessage)
 {
 	for(const char *pPreset : s_apQiaFenPresetWords)
 	{
-		if(str_find_nocase(pMessage, pPreset))
+		if(str_utf8_find_nocase(pMessage, pPreset))
 			return true;
 	}
 	return false;
 }
 
-static bool MessageMatchesQiaFenCustom(const char *pMessage, const char *pKeywords)
+static bool MessageMatchesKeywordList(const char *pMessage, const char *pKeywords, bool SkipQiaFenPresetWords)
 {
 	if(!pKeywords || pKeywords[0] == '\0')
 		return false;
@@ -244,13 +369,114 @@ static bool MessageMatchesQiaFenCustom(const char *pMessage, const char *pKeywor
 		str_utf8_trim_right(pToken);
 		if(pToken[0] == '\0')
 			continue;
-		if(IsQiaFenPresetWord(pToken))
+		if(SkipQiaFenPresetWords && IsQiaFenPresetWord(pToken))
 			continue;
-		if(str_find_nocase(pMessage, pToken))
+		if(str_utf8_find_nocase(pMessage, pToken))
 			return true;
 	}
 
 	return false;
+}
+
+static bool MatchAutoReplyRuleKeywords(const char *pMessage, char *pKeywords)
+{
+	char *pCursor = pKeywords;
+	while(*pCursor)
+	{
+		int SepLen = QiaFenSeparatorLength(pCursor);
+		while(*pCursor && SepLen > 0)
+		{
+			pCursor += SepLen;
+			SepLen = QiaFenSeparatorLength(pCursor);
+		}
+
+		char *pStart = pCursor;
+		while(*pCursor && QiaFenSeparatorLength(pCursor) == 0)
+			pCursor++;
+
+		if(pStart == pCursor)
+			break;
+
+		if(*pCursor)
+		{
+			const int CutLen = QiaFenSeparatorLength(pCursor);
+			*pCursor = '\0';
+			pCursor += CutLen;
+		}
+
+		char *pToken = (char *)str_utf8_skip_whitespaces(pStart);
+		str_utf8_trim_right(pToken);
+		if(pToken[0] == '\0')
+			continue;
+		if(str_utf8_find_nocase(pMessage, pToken))
+			return true;
+	}
+	return false;
+}
+
+static bool MatchAutoReplyRules(const char *pMessage, const char *pRules, char *pOutReply, size_t OutReplySize)
+{
+	if(!pRules || pRules[0] == '\0')
+		return false;
+
+	static constexpr int MAX_MATCHED_REPLIES = 32;
+	char aaMatchedReplies[MAX_MATCHED_REPLIES][256];
+	int MatchedReplyCount = 0;
+
+	const char *pCursor = pRules;
+	while(*pCursor)
+	{
+		char aLine[1024];
+		int LineLen = 0;
+		while(*pCursor && *pCursor != '\n' && *pCursor != '\r')
+		{
+			if(LineLen < (int)sizeof(aLine) - 1)
+				aLine[LineLen++] = *pCursor;
+			pCursor++;
+		}
+		aLine[LineLen] = '\0';
+
+		while(*pCursor == '\n' || *pCursor == '\r')
+			pCursor++;
+
+		char *pLine = (char *)str_utf8_skip_whitespaces(aLine);
+		str_utf8_trim_right(pLine);
+		if(pLine[0] == '\0' || pLine[0] == '#')
+			continue;
+
+		const char *pArrowConst = str_find(pLine, "=>");
+		if(!pArrowConst)
+			continue;
+		char *pArrow = pLine + (pArrowConst - pLine);
+		*pArrow = '\0';
+		pArrow += 2;
+
+		char *pKeywords = (char *)str_utf8_skip_whitespaces(pLine);
+		str_utf8_trim_right(pKeywords);
+		char *pReply = (char *)str_utf8_skip_whitespaces(pArrow);
+		str_utf8_trim_right(pReply);
+		if(pKeywords[0] == '\0' || pReply[0] == '\0')
+			continue;
+
+		char aKeywordsBuf[512];
+		str_copy(aKeywordsBuf, pKeywords, sizeof(aKeywordsBuf));
+		if(MatchAutoReplyRuleKeywords(pMessage, aKeywordsBuf))
+		{
+			if(MatchedReplyCount < MAX_MATCHED_REPLIES)
+			{
+				str_copy(aaMatchedReplies[MatchedReplyCount], pReply, sizeof(aaMatchedReplies[MatchedReplyCount]));
+			}
+			MatchedReplyCount++;
+		}
+	}
+
+	if(MatchedReplyCount <= 0)
+		return false;
+
+	const int StoredReplyCount = MatchedReplyCount < MAX_MATCHED_REPLIES ? MatchedReplyCount : MAX_MATCHED_REPLIES;
+	const int PickedIndex = secure_rand_below(StoredReplyCount);
+	str_copy(pOutReply, aaMatchedReplies[PickedIndex], OutReplySize);
+	return true;
 }
 
 bool CTClient::IsQiaFenFinishedMap() const
@@ -259,14 +485,8 @@ bool CTClient::IsQiaFenFinishedMap() const
 	if(!pServerBrowser)
 		return false;
 
-	const char *pCommunityId = nullptr;
-	const IServerBrowser::CServerEntry *pEntry = pServerBrowser->Find(Client()->ServerAddress());
-	if(pEntry)
-		pCommunityId = pEntry->m_Info.m_aCommunityId;
-	else if(GameClient()->m_ConnectServerInfo)
-		pCommunityId = GameClient()->m_ConnectServerInfo->m_aCommunityId;
-
-	if(!pCommunityId || pCommunityId[0] == '\0')
+	const char *pCommunityId = CurrentCommunityIdForFinishCheck();
+	if(!pCommunityId)
 		return false;
 
 	const CCommunity *pCommunity = pServerBrowser->Community(pCommunityId);
@@ -277,6 +497,166 @@ bool CTClient::IsQiaFenFinishedMap() const
 	if(!pMap || pMap[0] == '\0')
 		return false;
 	return pCommunity->HasRank(pMap) == CServerInfo::RANK_RANKED;
+}
+
+const char *CTClient::CurrentCommunityIdForFinishCheck() const
+{
+	IServerBrowser *pServerBrowser = ServerBrowser();
+	if(!pServerBrowser)
+		return nullptr;
+
+	const char *pCommunityId = nullptr;
+	const IServerBrowser::CServerEntry *pEntry = pServerBrowser->Find(Client()->ServerAddress());
+	if(pEntry)
+		pCommunityId = pEntry->m_Info.m_aCommunityId;
+	else if(GameClient()->m_ConnectServerInfo)
+		pCommunityId = GameClient()->m_ConnectServerInfo->m_aCommunityId;
+
+	if(!pCommunityId || pCommunityId[0] == '\0')
+		return nullptr;
+	return pCommunityId;
+}
+
+void CTClient::ResetFinishNameStatuses()
+{
+	for(auto &Entry : m_FinishNameStatuses)
+	{
+		auto &Status = Entry.second;
+		if(Status.m_pTask)
+			Status.m_pTask->Abort();
+	}
+	m_FinishNameStatuses.clear();
+	m_FinishStatusMap.clear();
+	m_FinishStatusCommunity.clear();
+}
+
+void CTClient::RefreshFinishNameStatusContext()
+{
+	const char *pCurrentMap = Client()->GetCurrentMap();
+	const char *pCurrentCommunity = CurrentCommunityIdForFinishCheck();
+	const std::string CurrentMap = pCurrentMap ? pCurrentMap : "";
+	const std::string CurrentCommunity = pCurrentCommunity ? pCurrentCommunity : "";
+	if(CurrentMap != m_FinishStatusMap || CurrentCommunity != m_FinishStatusCommunity)
+	{
+		ResetFinishNameStatuses();
+		m_FinishStatusMap = CurrentMap;
+		m_FinishStatusCommunity = CurrentCommunity;
+	}
+}
+
+bool CTClient::ParseFinishStatusResult(const json_value *pRoot, bool &Finished) const
+{
+	Finished = false;
+	if(!pRoot || pRoot->type != json_object || m_FinishStatusMap.empty())
+		return false;
+
+	const char *pMap = m_FinishStatusMap.c_str();
+	const char *pWantedCommunity = m_FinishStatusCommunity.empty() ? nullptr : m_FinishStatusCommunity.c_str();
+	const json_value *pCommunities = JsonObjectField(pRoot, "communities");
+
+	if(pWantedCommunity && pCommunities->type == json_array)
+	{
+		for(unsigned i = 0; i < pCommunities->u.array.length; ++i)
+		{
+			const json_value &Community = (*pCommunities)[i];
+			if(Community.type != json_object)
+				continue;
+			const json_value *pCommunityId = JsonObjectField(&Community, "id");
+			if(pCommunityId->type != json_string)
+				continue;
+			const char *pCommunityIdStr = json_string_get(pCommunityId);
+			if(str_comp(pCommunityIdStr, pWantedCommunity) != 0)
+				continue;
+			const json_value *pFinishes = JsonObjectField(&Community, "finishes");
+			if(pFinishes->type != json_array)
+				break;
+			Finished = JsonArrayContainsString(pFinishes, pMap);
+			return true;
+		}
+	}
+
+	if(pCommunities->type == json_array)
+	{
+		bool AnyCommunityFinishes = false;
+		for(unsigned i = 0; i < pCommunities->u.array.length; ++i)
+		{
+			const json_value &Community = (*pCommunities)[i];
+			if(Community.type != json_object)
+				continue;
+			const json_value *pFinishes = JsonObjectField(&Community, "finishes");
+			if(pFinishes->type != json_array)
+				continue;
+
+			AnyCommunityFinishes = true;
+			if(JsonArrayContainsString(pFinishes, pMap))
+			{
+				Finished = true;
+				return true;
+			}
+		}
+		if(AnyCommunityFinishes)
+			return true;
+	}
+
+	const json_value *pLegacyMaps = JsonObjectField(pRoot, "maps");
+	if(pLegacyMaps->type == json_array)
+	{
+		Finished = JsonArrayContainsString(pLegacyMaps, pMap);
+		return true;
+	}
+
+	return false;
+}
+
+bool CTClient::TryGetFinishStatusForName(const char *pName, bool &Finished)
+{
+	Finished = false;
+	if(!pName || pName[0] == '\0' || m_FinishStatusMap.empty())
+		return false;
+
+	SFinishNameStatus &Status = m_FinishNameStatuses[pName];
+	if(Status.m_pTask && Status.m_pTask->Done())
+	{
+		bool Parsed = false;
+		if(Status.m_pTask->State() == EHttpState::DONE && Status.m_pTask->StatusCode() == 200)
+		{
+			json_value *pRoot = Status.m_pTask->ResultJson();
+			Parsed = ParseFinishStatusResult(pRoot, Status.m_Finished);
+			if(pRoot)
+				json_value_free(pRoot);
+		}
+
+		Status.m_pTask = nullptr;
+		Status.m_HasResult = Parsed;
+		if(Parsed)
+		{
+			Status.m_NextRetryTick = 0;
+		}
+		else
+		{
+			Status.m_NextRetryTick = time_get() + time_freq() * FINISH_STATUS_RETRY_DELAY_SECONDS;
+		}
+	}
+
+	if(Status.m_HasResult)
+	{
+		Finished = Status.m_Finished;
+		return true;
+	}
+
+	if(Status.m_pTask || time_get() < Status.m_NextRetryTick)
+		return false;
+
+	char aEscapedName[256];
+	EscapeUrl(aEscapedName, sizeof(aEscapedName), pName);
+	char aUrl[512];
+	str_format(aUrl, sizeof(aUrl), "%s?name=%s", FINISH_STATUS_URL, aEscapedName);
+	Status.m_pTask = HttpGet(aUrl);
+	Status.m_pTask->Timeout(CTimeout{10000, 0, 500, 10});
+	Status.m_pTask->IpResolve(IPRESOLVE::V4);
+	Status.m_pTask->LogProgress(HTTPLOG::FAILURE);
+	Http()->Run(Status.m_pTask);
+	return false;
 }
 
 void CTClient::OnMessage(int MsgType, void *pRawMsg)
@@ -320,63 +700,157 @@ void CTClient::OnMessage(int MsgType, void *pRawMsg)
 		if(ClientId >= MAX_CLIENTS)
 			return;
 		int LocalId = GameClient()->m_Snap.m_LocalClientId;
-		if(ClientId == LocalId)
+		const auto IsOwnClientId = [&](int Id) {
+			if(Id < 0)
+				return false;
+			if(Id == GameClient()->m_aLocalIds[0])
+				return true;
+			return Client()->DummyConnected() && Id == GameClient()->m_aLocalIds[1];
+		};
+		const bool IsOwnMessage = IsOwnClientId(ClientId);
+		if(ClientId == LocalId && pMsg->m_pMessage != nullptr)
 			str_copy(m_PreviousOwnMessage, pMsg->m_pMessage);
 
 		// === 复读功能: 保存最新的公屏消息 ===
-		if(ClientId >= 0 && ClientId < MAX_CLIENTS && pMsg->m_Team == 0)
+		if(ClientId >= 0 && ClientId < MAX_CLIENTS && pMsg->m_Team == 0 && pMsg->m_pMessage != nullptr)
 		{
+			const char *pMessage = pMsg->m_pMessage;
+			const bool IsValidCandidate = pMessage[0] != '\0' && pMessage[0] != '/';
 			// 保存最新的公屏消息（不是自己发的）
-			if(ClientId != LocalId && pMsg->m_pMessage[0] != '/')
+			if(!IsOwnMessage && IsValidCandidate)
 			{
-				str_copy(m_aLastChatMessage, pMsg->m_pMessage, sizeof(m_aLastChatMessage));
+				str_copy(m_aLastChatMessage, pMessage, sizeof(m_aLastChatMessage));
+			}
+
+			// 自动加一：连续出现 2 句及以上非自己发送的相同公屏消息时，自动发送同内容一次。
+			if(g_Config.m_QmRepeatEnabled && g_Config.m_QmRepeatAutoAddOne && !IsOwnMessage && IsValidCandidate)
+			{
+				if(str_comp(m_aLastRepeatCandidate, pMessage) == 0)
+					++m_LastRepeatCandidateCount;
+				else
+				{
+					str_copy(m_aLastRepeatCandidate, pMessage, sizeof(m_aLastRepeatCandidate));
+					m_aLastAutoRepeatMessage[0] = '\0';
+					m_LastRepeatCandidateCount = 1;
+				}
+
+				if(m_LastRepeatCandidateCount >= 2)
+				{
+					const bool AlreadyRepeated = str_comp(m_aLastAutoRepeatMessage, pMessage) == 0;
+					const int64_t Now = time_get();
+					if(!AlreadyRepeated && Now - m_LastRepeatTime >= time_freq())
+					{
+						m_LastRepeatTime = Now;
+						str_copy(m_aLastAutoRepeatMessage, pMessage, sizeof(m_aLastAutoRepeatMessage));
+						GameClient()->m_Chat.SendChat(0, pMessage);
+					}
+				}
+			}
+			else if(!g_Config.m_QmRepeatEnabled || !g_Config.m_QmRepeatAutoAddOne)
+			{
+				m_aLastRepeatCandidate[0] = '\0';
+				m_aLastAutoRepeatMessage[0] = '\0';
+				m_LastRepeatCandidateCount = 0;
 			}
 		}
 
+		const auto TrySendAutoReply = [&](const char *pReply, bool UseDummy) -> bool {
+			if(!pReply || pReply[0] == '\0')
+				return false;
+			int Cooldown = g_Config.m_QmAutoReplyCooldown;
+			if(Cooldown < 0)
+				Cooldown = 0;
+			const int64_t Now = time_get();
+			if(Cooldown > 0 && Now - m_LastAutoReplyTime < (int64_t)Cooldown * time_freq())
+				return false;
+
+			const int TargetConn = UseDummy ? IClient::CONN_DUMMY : IClient::CONN_MAIN;
+			GameClient()->m_Chat.SendChatOnConn(TargetConn, 0, pReply);
+			m_LastAutoReplyTime = Now;
+			return true;
+		};
+
+		bool AutoReplyHandled = false;
+
 		// === 恰分功能 ===
-		if(g_Config.m_QmQiaFenEnabled && ClientId != LocalId && pMsg->m_Team == 0)
+		if(g_Config.m_QmQiaFenEnabled && !IsOwnMessage && pMsg->m_Team == 0 && pMsg->m_pMessage != nullptr)
 		{
 			if(!IsQiaFenFinishedMap())
 			{
-				// 检查是否是公屏消息且不是自己发的
 				const char *pMessage = pMsg->m_pMessage;
-				if(MessageMatchesQiaFenPreset(pMessage) || MessageMatchesQiaFenCustom(pMessage, g_Config.m_QmQiaFenKeywords))
+				const bool IsValidCandidate = pMessage[0] != '\0' && pMessage[0] != '/';
+				char aReply[256] = "";
+				bool Matched = false;
+
+				if(IsValidCandidate)
+				{
+					if(MessageMatchesQiaFenPreset(pMessage))
+					{
+						str_copy(aReply, s_pQiaFenDefaultReply, sizeof(aReply));
+						Matched = true;
+					}
+					else if(MatchAutoReplyRules(pMessage, g_Config.m_QmQiaFenRules, aReply, sizeof(aReply)))
+					{
+						Matched = true;
+					}
+					else if(MessageMatchesKeywordList(pMessage, g_Config.m_QmQiaFenKeywords, true))
+					{
+						str_copy(aReply, s_pQiaFenDefaultReply, sizeof(aReply));
+						Matched = true;
+					}
+				}
+
+				if(Matched)
 				{
 					const bool UseDummy = g_Config.m_QmQiaFenUseDummy && Client()->DummyConnected();
-					const int TargetConn = UseDummy ? IClient::CONN_DUMMY : IClient::CONN_MAIN;
+					AutoReplyHandled = TrySendAutoReply(aReply, UseDummy);
+					if(AutoReplyHandled)
+					{
+						// 在名字后面加"恰"
+						char aNewName[MAX_NAME_LENGTH];
+						char *pConfigName = UseDummy ? g_Config.m_ClDummyName : g_Config.m_PlayerName;
+						const int NameBufSize = UseDummy ? (int)sizeof(g_Config.m_ClDummyName) : (int)sizeof(g_Config.m_PlayerName);
+						const char *pCurrentName = pConfigName;
 
-					// 发送回复
-					GameClient()->m_Chat.SendChatOnConn(TargetConn, 0, "我要恰!!谢谢佬!!!!");
-					
-					// 在名字后面加"恰"
-					char aNewName[MAX_NAME_LENGTH];
-					char *pConfigName = UseDummy ? g_Config.m_ClDummyName : g_Config.m_PlayerName;
-					const int NameBufSize = UseDummy ? (int)sizeof(g_Config.m_ClDummyName) : (int)sizeof(g_Config.m_PlayerName);
-					const char *pCurrentName = pConfigName;
-					
-					// 检查名字是否已经以"恰"结尾
-					int NameLen = str_length(pCurrentName);
-					bool AlreadyHasQia = false;
-					
-					// 检查最后一个字符是否是"恰"（UTF-8：0xE6 0x81 0xB0）
-					if(NameLen >= 3 && 
-					   (unsigned char)pCurrentName[NameLen-3] == 0xE6 && 
-					   (unsigned char)pCurrentName[NameLen-2] == 0x81 && 
-					   (unsigned char)pCurrentName[NameLen-1] == 0xB0)
-					{
-						AlreadyHasQia = true;
+						// 检查名字是否已经以"恰"结尾
+						int NameLen = str_length(pCurrentName);
+						bool AlreadyHasQia = false;
+
+						// 检查最后一个字符是否是"恰"（UTF-8：0xE6 0x81 0xB0）
+						if(NameLen >= 3 &&
+							(unsigned char)pCurrentName[NameLen - 3] == 0xE6 &&
+							(unsigned char)pCurrentName[NameLen - 2] == 0x81 &&
+							(unsigned char)pCurrentName[NameLen - 1] == 0xB0)
+						{
+							AlreadyHasQia = true;
+						}
+
+						if(!AlreadyHasQia && NameLen + 3 < (int)sizeof(aNewName))
+						{
+							str_copy(aNewName, pCurrentName, sizeof(aNewName));
+							str_append(aNewName, "恰", sizeof(aNewName));
+							str_copy(pConfigName, aNewName, NameBufSize);
+							if(UseDummy)
+								GameClient()->SendDummyInfo(false);
+							else
+								GameClient()->SendInfo(false);
+						}
 					}
-					
-					if(!AlreadyHasQia && NameLen + 3 < (int)sizeof(aNewName))
-					{
-						str_copy(aNewName, pCurrentName, sizeof(aNewName));
-						str_append(aNewName, "恰", sizeof(aNewName));
-						str_copy(pConfigName, aNewName, NameBufSize);
-						if(UseDummy)
-							GameClient()->SendDummyInfo(false);
-						else
-							GameClient()->SendInfo(false);
-					}
+				}
+			}
+		}
+
+		// === 关键词回复 ===
+		if(!AutoReplyHandled && g_Config.m_QmKeywordReplyEnabled && !IsOwnMessage && pMsg->m_Team == 0 && pMsg->m_pMessage != nullptr)
+		{
+			const char *pMessage = pMsg->m_pMessage;
+			if(pMessage[0] != '\0' && pMessage[0] != '/')
+			{
+				char aReply[256] = "";
+				if(MatchAutoReplyRules(pMessage, g_Config.m_QmKeywordReplyRules, aReply, sizeof(aReply)))
+				{
+					const bool UseDummy = g_Config.m_QmKeywordReplyUseDummy && Client()->DummyConnected();
+					AutoReplyHandled = TrySendAutoReply(aReply, UseDummy);
 				}
 			}
 		}
@@ -734,7 +1208,11 @@ void CTClient::DoFinishCheck()
 	if(Client()->State() != IClient::STATE_ONLINE && Client()->State() != IClient::STATE_DEMOPLAYBACK)
 		return;
 	if(g_Config.m_TcChangeNameNearFinish <= 0)
+	{
+		if(!m_FinishNameStatuses.empty())
+			ResetFinishNameStatuses();
 		return;
+	}
 	m_FinishTextTimeout -= Client()->RenderFrameTime();
 	if(m_FinishTextTimeout > 0.0f)
 		return;
@@ -775,18 +1253,98 @@ void CTClient::DoFinishCheck()
 		GameClient()->m_aCheckInfo[Conn] = Client()->GameTickSpeed(); // 1 second
 	};
 	int Dummy = g_Config.m_ClDummy;
-	const auto &Player = GameClient()->m_aClients[GameClient()->m_aLocalIds[Dummy]];
+	const int LocalId = GameClient()->m_aLocalIds[Dummy];
+	if(LocalId < 0 || LocalId >= MAX_CLIENTS)
+		return;
+	const auto &Player = GameClient()->m_aClients[LocalId];
 	if(!Player.m_Active)
 		return;
-	const char *NewName = g_Config.m_TcFinishName;
-	if(str_comp(Player.m_aName, NewName) == 0)
+
+	RefreshFinishNameStatusContext();
+	if(m_FinishStatusMap.empty())
 		return;
+
+	// One-time runtime migration from legacy single-name config to unified queue config.
+	if(g_Config.m_TcFinishNameQueue[0] == '\0' && g_Config.m_TcFinishName[0] != '\0')
+	{
+		str_copy(g_Config.m_TcFinishNameQueue, g_Config.m_TcFinishName, sizeof(g_Config.m_TcFinishNameQueue));
+		g_Config.m_TcFinishName[0] = '\0';
+	}
+
+	std::vector<std::string> vNameQueue;
+	ParseFinishNameQueue(g_Config.m_TcFinishNameQueue, vNameQueue);
+	if(vNameQueue.empty())
+		return;
+
+	bool CurrentNameFinished = false;
+	const bool CurrentNameKnown = TryGetFinishStatusForName(Player.m_aName, CurrentNameFinished);
+	const char *pOwnName = Dummy == 0 ? g_Config.m_PlayerName : g_Config.m_ClDummyName;
+	if(!pOwnName || pOwnName[0] == '\0')
+		pOwnName = Player.m_aName;
+	bool OwnNameFinished = true;
+	bool OwnNameKnown = true;
+	if(g_Config.m_TcFinishNameRequireOwnFinished)
+	{
+		if(str_comp(pOwnName, Player.m_aName) == 0)
+		{
+			OwnNameKnown = CurrentNameKnown;
+			OwnNameFinished = CurrentNameFinished;
+		}
+		else
+		{
+			OwnNameKnown = TryGetFinishStatusForName(pOwnName, OwnNameFinished);
+		}
+	}
+	for(const std::string &Name : vNameQueue)
+	{
+		bool Ignored = false;
+		TryGetFinishStatusForName(Name.c_str(), Ignored);
+	}
+
 	if(!NearTile(Player.m_RenderPos, 10, TILE_FINISH))
 		return;
+
+	if(!CurrentNameKnown)
+	{
+		GameClient()->Echo(s_pFinishStatusPendingEcho);
+		return;
+	}
+	if(g_Config.m_TcFinishNameRequireOwnFinished)
+	{
+		if(!OwnNameKnown)
+		{
+			GameClient()->Echo(s_pFinishStatusPendingEcho);
+			return;
+		}
+		if(!OwnNameFinished)
+			return;
+	}
+	if(!CurrentNameFinished)
+		return;
+
+	const char *pRenameTarget = nullptr;
+	for(const std::string &Name : vNameQueue)
+	{
+		bool Finished = false;
+		if(!TryGetFinishStatusForName(Name.c_str(), Finished))
+		{
+			GameClient()->Echo(s_pFinishStatusPendingEcho);
+			return;
+		}
+		if(!Finished)
+		{
+			pRenameTarget = Name.c_str();
+			break;
+		}
+	}
+
+	if(!pRenameTarget || pRenameTarget[0] == '\0' || str_comp(Player.m_aName, pRenameTarget) == 0)
+		return;
+
 	char aBuf[64];
-	str_format(aBuf, sizeof(aBuf), TCLocalize("Changing name to %s near finish"), NewName);
+	str_format(aBuf, sizeof(aBuf), TCLocalize("终点前改名为 %s"), pRenameTarget);
 	GameClient()->Echo(aBuf);
-	SendUrgentRename(Dummy, NewName);
+	SendUrgentRename(Dummy, pRenameTarget);
 }
 
 bool CTClient::ServerCommandExists(const char *pCommand)
@@ -865,6 +1423,7 @@ void CTClient::OnRender()
 	CheckFreeze();
 	CheckWaterFall();
 	CheckFriendOnline();
+	CheckFriendEnterGreet();
 	CheckAutoUnspecOnUnfreeze(); // 检测解冻自动取消旁观
 	CheckAutoSwitchOnUnfreeze(); // HJ大佬辅助 - 检测自动切换
 	CheckAutoCloseChatOnUnfreeze(); // HJ大佬辅助 - 检测解冻后关闭聊天
@@ -1344,6 +1903,84 @@ void CTClient::CheckFriendOnline()
 	}
 }
 
+void CTClient::CheckFriendEnterGreet()
+{
+	if(Client()->State() != IClient::STATE_ONLINE)
+	{
+		if(m_FriendEnterInitialized || !m_FriendEnterOnline.empty())
+		{
+			m_FriendEnterOnline.clear();
+			m_FriendEnterInitialized = false;
+		}
+		return;
+	}
+
+	const int Enabled = g_Config.m_QmFriendEnterAutoGreet;
+	if(m_FriendEnterPrevEnabled != Enabled)
+	{
+		m_FriendEnterPrevEnabled = Enabled;
+		m_FriendEnterOnline.clear();
+		m_FriendEnterInitialized = false;
+	}
+
+	if(!Enabled)
+		return;
+
+	std::unordered_set<std::string> CurrentFriends;
+	std::vector<std::string> NewFriends;
+	const bool IgnoreClan = g_Config.m_ClFriendsIgnoreClan != 0;
+	const int LocalMain = GameClient()->m_aLocalIds[0];
+	const int LocalDummy = GameClient()->m_aLocalIds[1];
+	const bool HasDummy = Client()->DummyConnected();
+
+	for(int ClientId = 0; ClientId < MAX_CLIENTS; ++ClientId)
+	{
+		const auto &Client = GameClient()->m_aClients[ClientId];
+		if(!Client.m_Active)
+			continue;
+		if(ClientId == LocalMain || (HasDummy && ClientId == LocalDummy))
+			continue;
+		if(!GameClient()->Friends()->IsFriend(Client.m_aName, Client.m_aClan, true))
+			continue;
+
+		std::string Key = BuildFriendNotifyKey(Client.m_aName, Client.m_aClan, IgnoreClan);
+		CurrentFriends.insert(Key);
+		if(m_FriendEnterOnline.find(Key) == m_FriendEnterOnline.end())
+			NewFriends.push_back(Client.m_aName);
+	}
+
+	if(!m_FriendEnterInitialized)
+	{
+		m_FriendEnterOnline = std::move(CurrentFriends);
+		m_FriendEnterInitialized = true;
+		return;
+	}
+
+	m_FriendEnterOnline = std::move(CurrentFriends);
+
+	if(NewFriends.empty())
+		return;
+
+	if(g_Config.m_QmFriendEnterGreetText[0] == '\0')
+		return;
+
+	char aMsg[256];
+	aMsg[0] = '\0';
+	for(size_t i = 0; i < NewFriends.size(); ++i)
+	{
+		if(i > 0)
+			str_append(aMsg, " ", sizeof(aMsg));
+		str_append(aMsg, NewFriends[i].c_str(), sizeof(aMsg));
+	}
+
+	if(aMsg[0] != '\0')
+		str_append(aMsg, ": ", sizeof(aMsg));
+	str_append(aMsg, g_Config.m_QmFriendEnterGreetText, sizeof(aMsg));
+
+	if(aMsg[0] != '\0')
+		GameClient()->m_Chat.SendChat(0, aMsg);
+}
+
 void CTClient::CheckAutoUnspecOnUnfreeze()
 {
 	if(Client()->State() != IClient::STATE_ONLINE)
@@ -1639,6 +2276,15 @@ void CTClient::OnStateChange(int NewState, int OldState)
 	if(NewState != IClient::STATE_ONLINE)
 	{
 		ClearSwapCountdown();
+		m_aLastChatMessage[0] = '\0';
+		m_aLastRepeatCandidate[0] = '\0';
+		m_aLastAutoRepeatMessage[0] = '\0';
+		m_LastRepeatCandidateCount = 0;
+		m_LastRepeatTime = 0;
+		m_LastAutoReplyTime = 0;
+		ResetFinishNameStatuses();
+		m_FriendEnterOnline.clear();
+		m_FriendEnterInitialized = false;
 	}
 
 	// 进入服务器时重置统计数据

--- a/src/game/client/components/tclient/tclient.h
+++ b/src/game/client/components/tclient/tclient.h
@@ -5,6 +5,7 @@
 #include <engine/external/regex.h>
 #include <engine/shared/console.h>
 #include <engine/shared/http.h>
+#include <engine/shared/json.h>
 
 #include <game/client/component.h>
 
@@ -13,6 +14,7 @@
 #include <set>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 
 // 玩家统计数据结构
 struct SPlayerStats
@@ -113,12 +115,28 @@ class CTClient : public CComponent
 
 	float m_FinishTextTimeout = 0.0f;
 	void DoFinishCheck();
+	struct SFinishNameStatus
+	{
+		std::shared_ptr<CHttpRequest> m_pTask = nullptr;
+		bool m_HasResult = false;
+		bool m_Finished = false;
+		int64_t m_NextRetryTick = 0;
+	};
+	std::unordered_map<std::string, SFinishNameStatus> m_FinishNameStatuses;
+	std::string m_FinishStatusMap;
+	std::string m_FinishStatusCommunity;
+	void ResetFinishNameStatuses();
+	void RefreshFinishNameStatusContext();
+	const char *CurrentCommunityIdForFinishCheck() const;
+	bool ParseFinishStatusResult(const json_value *pRoot, bool &Finished) const;
+	bool TryGetFinishStatusForName(const char *pName, bool &Finished);
 	void StartUpdateDownload();
 	void ResetUpdateExeTask();
 	bool ReplaceClientFromUpdate();
 
 	bool ServerCommandExists(const char *pCommand);
 	bool IsQiaFenFinishedMap() const;
+	int64_t m_LastAutoReplyTime = 0;
 
 	// Water Fall Detection
 	bool m_aWasInDeath[NUM_DUMMIES] = {false, false};
@@ -170,7 +188,10 @@ class CTClient : public CComponent
 
 	// 复读功能
 	char m_aLastChatMessage[2048] = "";  // 最新一条公屏消息
-	int64_t m_LastRepeatTime = 0;           // 上次复读时间
+	char m_aLastRepeatCandidate[2048] = ""; // 自动加一候选消息
+	char m_aLastAutoRepeatMessage[2048] = ""; // 最近一次自动加一已发送内容
+	int m_LastRepeatCandidateCount = 0; // 自动加一候选出现次数
+	int64_t m_LastRepeatTime = 0; // 上次手动/自动复读时间
 	void RepeatLastMessage();
 	static void ConRepeat(IConsole::IResult *pResult, void *pUserData);
 
@@ -194,6 +215,11 @@ class CTClient : public CComponent
 	int m_FriendAutoRefreshPrevEnabled = -1;
 	int m_FriendAutoRefreshPrevSeconds = -1;
 	void CheckFriendOnline();
+	// 好友进图自动打招呼
+	std::unordered_set<std::string> m_FriendEnterOnline;
+	int m_FriendEnterPrevEnabled = -1;
+	bool m_FriendEnterInitialized = false;
+	void CheckFriendEnterGreet();
 
 	// Q1menG client recognition sync
 	std::shared_ptr<CHttpRequest> m_pQmClientAuthTokenTask = nullptr;

--- a/src/game/client/components/tclient/trails.cpp
+++ b/src/game/client/components/tclient/trails.cpp
@@ -47,13 +47,13 @@ void CTrails::OnRender()
 	{
 		for(int ClientId = 0; ClientId < MAX_CLIENTS; ClientId++)
 		{
-			const bool Local = GameClient()->m_Snap.m_LocalClientId == ClientId;
+			const bool IsLocalClient = GameClient()->IsLocalClientId(ClientId);
 
 			if(!GameClient()->m_Snap.m_aCharacters[ClientId].m_Active)
 				continue;
 
-			// Only render for local player (can be extended to others if desired)
-			if(!Local)
+			// Render for both local players (main + dummy when connected).
+			if(!IsLocalClient)
 				continue;
 
 			vec2 Position = GameClient()->m_aClients[ClientId].m_RenderPos;
@@ -76,13 +76,13 @@ void CTrails::OnRender()
 	{
 		for(int ClientId = 0; ClientId < MAX_CLIENTS; ClientId++)
 		{
-			const bool Local = GameClient()->m_Snap.m_LocalClientId == ClientId;
+			const bool IsLocalClient = GameClient()->IsLocalClientId(ClientId);
 
 			if(!GameClient()->m_Snap.m_aCharacters[ClientId].m_Active)
 				continue;
 			
-			if(Local)
-				continue; // Skip local player (already handled above)
+			if(IsLocalClient)
+				continue; // Remote rendering is only for other players.
 
 			// Check if this is a recognized Q1menG client
 			if(!GameClient()->IsQ1menGClientRecognized(ClientId))

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1956,6 +1956,7 @@ void CGameClient::OnNewSnapshot()
 					pClient->m_FreezeEnd = pCharacterData->m_FreezeEnd;
 					pClient->m_DeepFrozen = pCharacterData->m_FreezeEnd == -1;
 					pClient->m_LiveFrozen = (pCharacterData->m_Flags & CHARACTERFLAG_MOVEMENTS_DISABLED) != 0;
+					pClient->m_IsInFreeze = (pCharacterData->m_Flags & CHARACTERFLAG_IN_FREEZE) != 0;
 
 					// Telegun
 					pClient->m_HasTelegunGrenade = pCharacterData->m_Flags & CHARACTERFLAG_TELEGUN_GRENADE;
@@ -2531,15 +2532,24 @@ void CGameClient::UpdateEditorIngameMoved()
 	}
 }
 
-void CGameClient::HandleHammerSkinSwap(CCharacter *pChar, int DummyIndex)
+void CGameClient::HandleHammerSkinSwap(CCharacter *pChar)
 {
 	if(!g_Config.m_QmHammerSwapSkin || !pChar)
 		return;
 
-	const int AttackTick = pChar->GetAttackTick();
-	if(AttackTick == m_aLastHammerSkinSwapAttackTick[DummyIndex])
+	const int Cid = pChar->GetCid();
+	int TeeIndex = -1;
+	if(Cid == m_aLocalIds[0])
+		TeeIndex = 0;
+	else if(Cid == m_aLocalIds[1])
+		TeeIndex = 1;
+	if(TeeIndex < 0)
 		return;
-	m_aLastHammerSkinSwapAttackTick[DummyIndex] = AttackTick;
+
+	const int AttackTick = pChar->GetAttackTick();
+	if(AttackTick == m_aLastHammerSkinSwapAttackTick[TeeIndex])
+		return;
+	m_aLastHammerSkinSwapAttackTick[TeeIndex] = AttackTick;
 
 	if(pChar->GetActiveWeapon() != WEAPON_HAMMER || pChar->HammerHitDisabled())
 		return;
@@ -2584,7 +2594,7 @@ void CGameClient::HandleHammerSkinSwap(CCharacter *pChar, int DummyIndex)
 		return;
 
 	bool Changed = false;
-	if(DummyIndex != 0)
+	if(TeeIndex == 1)
 	{
 		if(str_comp(g_Config.m_ClDummySkin, TargetClient.m_aSkinName) != 0)
 		{
@@ -2924,9 +2934,9 @@ void CGameClient::OnPredict()
 		}
 
 		m_PredictedWorld.Tick();
-		HandleHammerSkinSwap(pLocalChar, 0);
+		HandleHammerSkinSwap(pLocalChar);
 		if(pDummyChar)
-			HandleHammerSkinSwap(pDummyChar, 1);
+			HandleHammerSkinSwap(pDummyChar);
 		HandleRandomEmoteOnHit(pLocalChar, 0);
 		if(pDummyChar)
 			HandleRandomEmoteOnHit(pDummyChar, 1);
@@ -3581,6 +3591,7 @@ void CGameClient::CClientData::Reset()
 	m_FreezeEnd = 0;
 	m_DeepFrozen = false;
 	m_LiveFrozen = false;
+	m_IsInFreeze = false;
 
 	m_Predicted.Reset();
 	m_PrevPredicted.Reset();
@@ -5374,8 +5385,7 @@ static bool UnknownMapSettingCallback(const char *pCommand, void *pUser)
 void CGameClient::LoadMapSettings()
 {
 	IEngineMap *pMap = Kernel()->RequestInterface<IEngineMap>();
-
-	m_MapBugs = CMapBugs::Create(Client()->GetCurrentMap(), pMap->MapSize(), pMap->Sha256());
+	m_MapBugs = CMapBugs::Create(Client()->GetCurrentMap(), 0, SHA256_ZEROED);
 
 	// Reset Tunezones
 	for(int TuneZone = 0; TuneZone < NUM_TUNEZONES; TuneZone++)
@@ -5387,6 +5397,13 @@ void CGameClient::LoadMapSettings()
 		TuningList()[TuneZone].Set("shotgun_speed", 500);
 		TuningList()[TuneZone].Set("shotgun_speeddiff", 0);
 	}
+
+	if(!pMap || !pMap->IsLoaded())
+	{
+		return;
+	}
+
+	m_MapBugs = CMapBugs::Create(Client()->GetCurrentMap(), pMap->MapSize(), pMap->Sha256());
 
 	// Load map tunings
 	int Start, Num;

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -278,7 +278,7 @@ private:
 
 	int m_EditorMovementDelay = 5;
 	void UpdateEditorIngameMoved();
-	void HandleHammerSkinSwap(CCharacter *pChar, int DummyIndex);
+	void HandleHammerSkinSwap(CCharacter *pChar);
 	void HandleRandomEmoteOnHit(CCharacter *pLocalChar, int DummyIndex);
 
 	int m_PredictedTick;
@@ -525,6 +525,7 @@ public:
 		int m_FreezeEnd;
 		bool m_DeepFrozen;
 		bool m_LiveFrozen;
+		bool m_IsInFreeze;
 
 		CCharacterCore m_Predicted;
 		CCharacterCore m_PrevPredicted;


### PR DESCRIPTION
- 在断言日志中添加操作系统版本和更多诊断信息，调整崩溃转储路径为"dumps/QmClient_Crash"
- 修正窗口显示状态检测，避免最小化窗口被识别为打开状态
- 优化Vulkan后端SwapChain管理及渲染暂停逻辑
- 限制背景绘制保存仅在联机或录像回放时有效
- 新增Deepfly模式识别及绑定命令规范化，自动设置对应模式配置
- 调整挂起检测日志，增加详细诊断数据和路径统一
- 修改锤人换皮肤逻辑以多本体兼容，提升稳定性
- HUD新增显示分身同步状态，完善键状态信息展示
- Shutdown实现超时等待并自动分离剩余线程，避免阻塞关闭流程
- 多处配置项新增和修正，包括“显示分身同步状态”和Qm模块相关选项
- 客户端对地图未加载状态做更严格判断，避免错误操作
- 微调各种显示和界面布局，确保元素不超出显示边界

