### PR TITLE
## FEAT - 新增 TencentCloud 翻译后端和材质商店

### DIFF
--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -298,22 +298,44 @@ IGraphics::CTextureHandle CGraphics_Threaded::FindFreeTextureIndex()
 	if(m_FirstFreeTexture == CurSize)
 	{
 		m_vTextureIndices.resize(CurSize * 2);
+		m_vTextureGenerations.resize(CurSize * 2);
 		for(size_t i = 0; i < CurSize; ++i)
 			m_vTextureIndices[CurSize + i] = CurSize + i + 1;
 	}
 	const size_t Tex = m_FirstFreeTexture;
 	m_FirstFreeTexture = m_vTextureIndices[Tex];
 	m_vTextureIndices[Tex] = -1;
-	return CreateTextureHandle(Tex);
+	return CreateTextureHandle(Tex, m_vTextureGenerations[Tex]);
+}
+
+bool CGraphics_Threaded::IsTextureHandleAllocated(CTextureHandle TextureId) const
+{
+	if(!TextureId.IsValid())
+		return false;
+
+	const size_t TextureIndex = TextureId.Id();
+	if(TextureIndex >= m_vTextureIndices.size() || TextureIndex >= m_vTextureGenerations.size())
+		return false;
+
+	return m_vTextureIndices[TextureIndex] == -1 && m_vTextureGenerations[TextureIndex] == TextureId.Generation();
 }
 
 void CGraphics_Threaded::FreeTextureIndex(CTextureHandle *pIndex)
 {
-	dbg_assert(pIndex->IsValid(), "Cannot free invalid texture index");
-	dbg_assert(m_vTextureIndices[pIndex->Id()] == -1, "Cannot free already freed texture index");
+	if(!pIndex->IsValid())
+		return;
+
+	if(!IsTextureHandleAllocated(*pIndex))
+	{
+		if(g_Config.m_Debug)
+			log_trace("graphics/texture", "Ignoring stale texture handle %d during free.", pIndex->Id());
+		pIndex->Invalidate();
+		return;
+	}
 
 	m_vTextureIndices[pIndex->Id()] = m_FirstFreeTexture;
 	m_FirstFreeTexture = pIndex->Id();
+	++m_vTextureGenerations[pIndex->Id()];
 	pIndex->Invalidate();
 }
 
@@ -321,6 +343,14 @@ void CGraphics_Threaded::UnloadTexture(CTextureHandle *pIndex)
 {
 	if(pIndex->IsNullTexture() || !pIndex->IsValid())
 		return;
+
+	if(!IsTextureHandleAllocated(*pIndex))
+	{
+		if(g_Config.m_Debug)
+			log_trace("graphics/texture", "Ignoring unload of stale texture handle %d.", pIndex->Id());
+		pIndex->Invalidate();
+		return;
+	}
 
 	CCommandBuffer::SCommand_Texture_Destroy Cmd;
 	Cmd.m_Slot = pIndex->Id();
@@ -503,20 +533,22 @@ bool CGraphics_Threaded::LoadTextTextures(size_t Width, size_t Height, CTextureH
 
 bool CGraphics_Threaded::UnloadTextTextures(CTextureHandle &TextTexture, CTextureHandle &TextOutlineTexture)
 {
-	CCommandBuffer::SCommand_TextTextures_Destroy Cmd;
-	Cmd.m_Slot = TextTexture.Id();
-	Cmd.m_SlotOutline = TextOutlineTexture.Id();
-	AddCmd(Cmd);
-
-	if(TextTexture.IsValid())
-		FreeTextureIndex(&TextTexture);
-	if(TextOutlineTexture.IsValid())
-		FreeTextureIndex(&TextOutlineTexture);
+	UnloadTexture(&TextTexture);
+	UnloadTexture(&TextOutlineTexture);
 	return true;
 }
 
 bool CGraphics_Threaded::UpdateTextTexture(CTextureHandle TextureId, int x, int y, size_t Width, size_t Height, uint8_t *pData, bool IsMovedPointer)
 {
+	if(!IsTextureHandleAllocated(TextureId))
+	{
+		if(IsMovedPointer)
+			free(pData);
+		if(g_Config.m_Debug && TextureId.IsValid())
+			log_trace("graphics/texture", "Ignoring update of stale text texture handle %d.", TextureId.Id());
+		return false;
+	}
+
 	CCommandBuffer::SCommand_TextTexture_Update Cmd;
 	Cmd.m_Slot = TextureId.Id();
 	Cmd.m_X = x;
@@ -542,6 +574,15 @@ bool CGraphics_Threaded::UpdateTextTexture(CTextureHandle TextureId, int x, int 
 
 bool CGraphics_Threaded::UpdateTexture(CTextureHandle TextureId, int x, int y, size_t Width, size_t Height, uint8_t *pData, bool IsMovedPointer)
 {
+	if(!IsTextureHandleAllocated(TextureId))
+	{
+		if(IsMovedPointer)
+			free(pData);
+		if(g_Config.m_Debug && TextureId.IsValid())
+			log_trace("graphics/texture", "Ignoring update of stale texture handle %d.", TextureId.Id());
+		return false;
+	}
+
 	CCommandBuffer::SCommand_Texture_Update Cmd;
 	Cmd.m_Slot = TextureId.Id();
 	Cmd.m_X = x;
@@ -756,7 +797,12 @@ void CGraphics_Threaded::ScreenshotDirect(bool *pSwapped)
 void CGraphics_Threaded::TextureSet(CTextureHandle TextureId)
 {
 	dbg_assert(m_Drawing == EDrawing::NONE, "called Graphics()->TextureSet within begin");
-	dbg_assert(!TextureId.IsValid() || m_vTextureIndices[TextureId.Id()] == -1, "Texture handle was not invalid, but also did not correlate to an existing texture.");
+	if(TextureId.IsValid() && !IsTextureHandleAllocated(TextureId))
+	{
+		if(g_Config.m_Debug)
+			log_trace("graphics/texture", "Ignoring stale texture handle %d during bind.", TextureId.Id());
+		TextureId.Invalidate();
+	}
 	m_State.m_Texture = TextureId.Id();
 }
 
@@ -2483,6 +2529,7 @@ int CGraphics_Threaded::Init()
 	// init textures
 	m_FirstFreeTexture = 0;
 	m_vTextureIndices.resize(CCommandBuffer::MAX_TEXTURES);
+	m_vTextureGenerations.resize(CCommandBuffer::MAX_TEXTURES);
 	for(size_t i = 0; i < m_vTextureIndices.size(); ++i)
 		m_vTextureIndices[i] = i + 1;
 

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -800,6 +800,8 @@ class CGraphics_Threaded : public IEngineGraphics
 	CTextureHandle m_NullTexture;
 
 	std::vector<int> m_vTextureIndices;
+	// Tracks slot generations so copied handles become stale once a slot is freed and reused.
+	std::vector<uint32_t> m_vTextureGenerations;
 	size_t m_FirstFreeTexture;
 	int m_TextureMemoryUsage;
 
@@ -942,6 +944,7 @@ public:
 	void LinesBatchDraw(CLineItemBatch *pBatch, const CLineItem *pArray, size_t Num) override;
 
 	IGraphics::CTextureHandle FindFreeTextureIndex();
+	bool IsTextureHandleAllocated(CTextureHandle TextureId) const;
 	void FreeTextureIndex(CTextureHandle *pIndex);
 	void UnloadTexture(IGraphics::CTextureHandle *pIndex) override;
 	void LoadTextureAddWarning(size_t Width, size_t Height, int Flags, const char *pTexName);

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -208,17 +208,24 @@ public:
 	{
 		friend class IGraphics;
 		int m_Id;
+		uint32_t m_Generation;
 
 	public:
 		CTextureHandle() :
-			m_Id(-1)
+			m_Id(-1),
+			m_Generation(0)
 		{
 		}
 
 		bool IsValid() const { return Id() >= 0; }
-		bool IsNullTexture() const { return Id() == 0; }
+		bool IsNullTexture() const { return IsValid() && Id() == 0; }
 		int Id() const { return m_Id; }
-		void Invalidate() { m_Id = -1; }
+		uint32_t Generation() const { return m_Generation; }
+		void Invalidate()
+		{
+			m_Id = -1;
+			m_Generation = 0;
+		}
 	};
 
 	int ScreenWidth() const { return m_ScreenWidth; }
@@ -608,10 +615,11 @@ public:
 	virtual bool IsBackendInitialized() = 0;
 
 protected:
-	CTextureHandle CreateTextureHandle(int Index)
+	CTextureHandle CreateTextureHandle(int Index, uint32_t Generation = 0)
 	{
 		CTextureHandle Tex;
 		Tex.m_Id = Index;
+		Tex.m_Generation = Generation;
 		return Tex;
 	}
 

--- a/src/game/client/components/menus_settings_assets.cpp
+++ b/src/game/client/components/menus_settings_assets.cpp
@@ -233,19 +233,20 @@ static int s_CurCustomTab = ASSETS_TAB_ENTITIES;
 
 namespace
 {
-constexpr const char *WORKSHOP_HUD_ASSETS_URL = "https://3gqy.cn/api/v1/assets?page=1&pageSize=64&category=%E7%95%8C%E9%9D%A2%EF%BC%88HUD%EF%BC%89";
-constexpr const char *WORKSHOP_HUD_CATEGORY = "界面（HUD）";
-constexpr const char *WORKSHOP_ENTITIES_ASSETS_URL = "https://3gqy.cn/api/v1/assets?page=1&pageSize=96&category=%E5%AE%9E%E4%BD%93%EF%BC%88ENTITIES%EF%BC%89";
-constexpr const char *WORKSHOP_ENTITIES_CATEGORY = "实体（Entities）";
+constexpr const char *WORKSHOP_ASSETS_URL = "https://www.ddrace.cn/data/assets.json";
+constexpr const char *WORKSHOP_HUD_ASSETS_URL = WORKSHOP_ASSETS_URL;
+constexpr const char *WORKSHOP_HUD_CATEGORY = "HUD";
+constexpr const char *WORKSHOP_ENTITIES_ASSETS_URL = WORKSHOP_ASSETS_URL;
+constexpr const char *WORKSHOP_ENTITIES_CATEGORY = "实体层";
 constexpr const char *WORKSHOP_ENTITIES_CATEGORY_ALT = "实体（ENTITIES）";
-constexpr const char *WORKSHOP_GAME_ASSETS_URL = "https://3gqy.cn/api/v1/assets?page=1&pageSize=96&category=%E6%B8%B8%E6%88%8F%EF%BC%88GAME%EF%BC%89";
-constexpr const char *WORKSHOP_GAME_CATEGORY = "游戏（Game）";
+constexpr const char *WORKSHOP_GAME_ASSETS_URL = WORKSHOP_ASSETS_URL;
+constexpr const char *WORKSHOP_GAME_CATEGORY = "游戏";
 constexpr const char *WORKSHOP_GAME_CATEGORY_ALT = "游戏（GAME）";
-constexpr const char *WORKSHOP_EMOTICONS_ASSETS_URL = "https://3gqy.cn/api/v1/assets?page=1&pageSize=192&category=%E8%A1%A8%E6%83%85%EF%BC%88EMOTICONS%EF%BC%89";
-constexpr const char *WORKSHOP_EMOTICONS_CATEGORY = "表情（Emoticons）";
+constexpr const char *WORKSHOP_EMOTICONS_ASSETS_URL = WORKSHOP_ASSETS_URL;
+constexpr const char *WORKSHOP_EMOTICONS_CATEGORY = "表情";
 constexpr const char *WORKSHOP_EMOTICONS_CATEGORY_ALT = "表情（EMOTICONS）";
-constexpr const char *WORKSHOP_PARTICLES_ASSETS_URL = "https://3gqy.cn/api/v1/assets?page=1&pageSize=192&category=%E7%B2%92%E5%AD%90%EF%BC%88PARTICLES%EF%BC%89";
-constexpr const char *WORKSHOP_PARTICLES_CATEGORY = "粒子（Particles）";
+constexpr const char *WORKSHOP_PARTICLES_ASSETS_URL = WORKSHOP_ASSETS_URL;
+constexpr const char *WORKSHOP_PARTICLES_CATEGORY = "粒子";
 constexpr const char *WORKSHOP_PARTICLES_CATEGORY_ALT = "粒子（PARTICLES）";
 
 struct SWorkshopHudAsset
@@ -393,6 +394,54 @@ std::string BuildSafeFilename(const char *pName, const char *pFallbackName, cons
 	return aFilename;
 }
 
+std::string NormalizeWorkshopAssetUrl(const char *pUrl)
+{
+	if(!pUrl || pUrl[0] == '\0')
+		return {};
+
+	std::string Url = pUrl;
+	const size_t TransformPos = Url.find("!/");
+	if(TransformPos != std::string::npos)
+		Url.resize(TransformPos);
+	return Url;
+}
+
+bool WorkshopCategoryMatches(const char *pCategoryValue, const char *pCategoryFilter, const char *pCategoryFilterAlt, const char *pInstallFolder)
+{
+	if(!pCategoryValue || pCategoryValue[0] == '\0')
+		return false;
+
+	if((pCategoryFilter && pCategoryFilter[0] != '\0' && str_comp(pCategoryValue, pCategoryFilter) == 0) ||
+		(pCategoryFilterAlt && pCategoryFilterAlt[0] != '\0' && str_comp(pCategoryValue, pCategoryFilterAlt) == 0))
+	{
+		return true;
+	}
+
+	if(!pInstallFolder || pInstallFolder[0] == '\0')
+		return false;
+
+	if(str_comp(pInstallFolder, "hud") == 0)
+		return str_comp(pCategoryValue, "HUD") == 0 || str_comp(pCategoryValue, "界面（HUD）") == 0;
+	if(str_comp(pInstallFolder, "entities") == 0)
+		return str_comp(pCategoryValue, "实体层") == 0 ||
+			str_comp(pCategoryValue, "实体（Entities）") == 0 ||
+			str_comp(pCategoryValue, "实体（ENTITIES）") == 0;
+	if(str_comp(pInstallFolder, "game") == 0)
+		return str_comp(pCategoryValue, "游戏") == 0 ||
+			str_comp(pCategoryValue, "游戏（Game）") == 0 ||
+			str_comp(pCategoryValue, "游戏（GAME）") == 0;
+	if(str_comp(pInstallFolder, "emoticons") == 0)
+		return str_comp(pCategoryValue, "表情") == 0 ||
+			str_comp(pCategoryValue, "表情（Emoticons）") == 0 ||
+			str_comp(pCategoryValue, "表情（EMOTICONS）") == 0;
+	if(str_comp(pInstallFolder, "particles") == 0)
+		return str_comp(pCategoryValue, "粒子") == 0 ||
+			str_comp(pCategoryValue, "粒子（Particles）") == 0 ||
+			str_comp(pCategoryValue, "粒子（PARTICLES）") == 0;
+
+	return false;
+}
+
 bool ParseWorkshopAssets(const json_value *pRoot, const char *pCategoryFilter, const char *pCategoryFilterAlt, const char *pInstallFolder, std::vector<SWorkshopHudAsset> &vOut, char *pErr, int ErrSize)
 {
 	vOut.clear();
@@ -402,28 +451,34 @@ bool ParseWorkshopAssets(const json_value *pRoot, const char *pCategoryFilter, c
 		return false;
 	}
 
-	const json_value *pCode = json_object_get(pRoot, "code");
-	if(pCode == &json_value_none || pCode->type != json_integer || pCode->u.integer != 0)
+	const json_value *pAssets = json_object_get(pRoot, "assets");
+	bool LegacyApi = false;
+	if(pAssets == &json_value_none)
 	{
-		const json_value *pMessage = json_object_get(pRoot, "message");
-		if(pMessage != &json_value_none && pMessage->type == json_string)
-			str_copy(pErr, json_string_get(pMessage), ErrSize);
-		else
-			str_copy(pErr, "Workshop api returned error", ErrSize);
+		const json_value *pCode = json_object_get(pRoot, "code");
+		if(pCode != &json_value_none && (pCode->type != json_integer || pCode->u.integer != 0))
+		{
+			const json_value *pMessage = json_object_get(pRoot, "message");
+			if(pMessage != &json_value_none && pMessage->type == json_string)
+				str_copy(pErr, json_string_get(pMessage), ErrSize);
+			else
+				str_copy(pErr, "Workshop api returned error", ErrSize);
+			return false;
+		}
+		pAssets = json_object_get(pRoot, "data");
+		LegacyApi = true;
+	}
+
+	if(pAssets == &json_value_none || pAssets->type != json_array)
+	{
+		str_copy(pErr, "Workshop asset list is missing", ErrSize);
 		return false;
 	}
 
-	const json_value *pData = json_object_get(pRoot, "data");
-	if(pData == &json_value_none || pData->type != json_array)
+	vOut.reserve(pAssets->u.array.length);
+	for(unsigned i = 0; i < pAssets->u.array.length; ++i)
 	{
-		str_copy(pErr, "Workshop data field is missing", ErrSize);
-		return false;
-	}
-
-	vOut.reserve(pData->u.array.length);
-	for(unsigned i = 0; i < pData->u.array.length; ++i)
-	{
-		const json_value &Entry = (*pData)[i];
+		const json_value &Entry = (*pAssets)[i];
 		if(Entry.type != json_object)
 			continue;
 
@@ -431,12 +486,14 @@ bool ParseWorkshopAssets(const json_value *pRoot, const char *pCategoryFilter, c
 		if(pCategory == &json_value_none || pCategory->type != json_string)
 			continue;
 		const char *pCategoryValue = json_string_get(pCategory);
-		const bool CategoryMatchesPrimary = pCategoryFilter == nullptr || pCategoryFilter[0] == '\0' || str_comp(pCategoryValue, pCategoryFilter) == 0;
-		const bool CategoryMatchesAlt = pCategoryFilterAlt != nullptr && pCategoryFilterAlt[0] != '\0' && str_comp(pCategoryValue, pCategoryFilterAlt) == 0;
-		if(!CategoryMatchesPrimary && !CategoryMatchesAlt)
+		if(!WorkshopCategoryMatches(pCategoryValue, pCategoryFilter, pCategoryFilterAlt, pInstallFolder))
 			continue;
 
-		const json_value *pImage = json_object_get(&Entry, "image");
+		const json_value *pImage = json_object_get(&Entry, LegacyApi ? "image" : "image_url");
+		if(pImage == &json_value_none)
+			pImage = json_object_get(&Entry, "image");
+		if(pImage == &json_value_none)
+			pImage = json_object_get(&Entry, "image_url");
 		if(pImage == &json_value_none || pImage->type != json_string)
 			continue;
 
@@ -448,7 +505,9 @@ bool ParseWorkshopAssets(const json_value *pRoot, const char *pCategoryFilter, c
 		Asset.m_Id = pId != &json_value_none && pId->type == json_string ? json_string_get(pId) : std::to_string(i);
 		Asset.m_Name = pName != &json_value_none && pName->type == json_string ? json_string_get(pName) : Asset.m_Id;
 		Asset.m_Author = pAuthor != &json_value_none && pAuthor->type == json_string ? json_string_get(pAuthor) : "";
-		Asset.m_ImageUrl = json_string_get(pImage);
+		Asset.m_ImageUrl = NormalizeWorkshopAssetUrl(json_string_get(pImage));
+		if(Asset.m_ImageUrl.empty())
+			continue;
 
 		char aExt[16];
 		GuessUrlExtension(Asset.m_ImageUrl.c_str(), aExt, sizeof(aExt));
@@ -562,9 +621,10 @@ void CMenus::ClearCustomItems(int CurTab)
 	{
 		for(auto &Entity : m_vEntitiesList)
 		{
+			Graphics()->UnloadTexture(&Entity.m_RenderTexture);
 			for(auto &Image : Entity.m_aImages)
 			{
-				Graphics()->UnloadTexture(&Image.m_Texture);
+				Image.m_Texture.Invalidate();
 			}
 		}
 		m_vEntitiesList.clear();
@@ -1149,23 +1209,34 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 			bool Parsed = false;
 			char aError[sizeof(WorkshopState.m_aError)] = "";
 			std::vector<SWorkshopHudAsset> vParsedAssets;
-
-			if(WorkshopState.m_pListTask->State() == EHttpState::DONE && WorkshopState.m_pListTask->StatusCode() == 200)
+			const EHttpState ListTaskState = WorkshopState.m_pListTask->State();
+			if(ListTaskState == EHttpState::DONE)
 			{
-				json_value *pJson = WorkshopState.m_pListTask->ResultJson();
-				if(pJson)
+				if(WorkshopState.m_pListTask->StatusCode() == 200)
 				{
-					Parsed = ParseWorkshopAssets(pJson, pWorkshopCategory, pWorkshopCategoryAlt, pInstallFolder, vParsedAssets, aError, sizeof(aError));
-					json_value_free(pJson);
+					json_value *pJson = WorkshopState.m_pListTask->ResultJson();
+					if(pJson)
+					{
+						Parsed = ParseWorkshopAssets(pJson, pWorkshopCategory, pWorkshopCategoryAlt, pInstallFolder, vParsedAssets, aError, sizeof(aError));
+						json_value_free(pJson);
+					}
+					else
+					{
+						str_copy(aError, "Workshop json parse failed", sizeof(aError));
+					}
 				}
 				else
 				{
-					str_copy(aError, "Workshop json parse failed", sizeof(aError));
+					str_format(aError, sizeof(aError), "Workshop request failed (%d)", WorkshopState.m_pListTask->StatusCode());
 				}
+			}
+			else if(ListTaskState == EHttpState::ABORTED)
+			{
+				str_copy(aError, "Workshop request aborted", sizeof(aError));
 			}
 			else
 			{
-				str_format(aError, sizeof(aError), "Workshop request failed (%d)", WorkshopState.m_pListTask->StatusCode());
+				str_copy(aError, "Workshop request failed", sizeof(aError));
 			}
 
 			ResetWorkshopState(WorkshopState, Graphics(), true);

--- a/src/game/client/components/qmclient/translate.cpp
+++ b/src/game/client/components/qmclient/translate.cpp
@@ -1,6 +1,8 @@
 #include "translate.h"
 
+#include <base/hash.h>
 #include <base/log.h>
+#include <base/system.h>
 
 #include <engine/shared/json.h>
 #include <engine/shared/jsonwriter.h>
@@ -11,7 +13,228 @@
 #include <game/localization.h>
 
 #include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstdlib>
+#include <ctime>
 #include <memory>
+#include <string>
+
+namespace
+{
+constexpr size_t TC3_HMAC_BLOCK_SIZE = 64;
+constexpr const char *TENCENTCLOUD_TMT_ACTION = "TextTranslate";
+constexpr const char *TENCENTCLOUD_TMT_VERSION = "2018-03-21";
+constexpr const char *TENCENTCLOUD_TMT_SERVICE = "tmt";
+constexpr const char *TENCENTCLOUD_TMT_DEFAULT_ENDPOINT = "https://tmt.tencentcloudapi.com/";
+constexpr const char *TENCENTCLOUD_SECRET_ID_FALLBACK = "";
+constexpr const char *TENCENTCLOUD_SECRET_KEY_FALLBACK = "";
+
+SHA256_DIGEST HmacSha256(const unsigned char *pKey, size_t KeyLength, const unsigned char *pData, size_t DataLength)
+{
+	std::array<unsigned char, TC3_HMAC_BLOCK_SIZE> aKeyBlock{};
+	if(KeyLength > TC3_HMAC_BLOCK_SIZE)
+	{
+		const SHA256_DIGEST KeyDigest = sha256(pKey, KeyLength);
+		mem_copy(aKeyBlock.data(), KeyDigest.data, sizeof(KeyDigest.data));
+	}
+	else if(KeyLength > 0)
+	{
+		mem_copy(aKeyBlock.data(), pKey, KeyLength);
+	}
+
+	std::array<unsigned char, TC3_HMAC_BLOCK_SIZE> aInnerPad{};
+	std::array<unsigned char, TC3_HMAC_BLOCK_SIZE> aOuterPad{};
+	for(size_t i = 0; i < TC3_HMAC_BLOCK_SIZE; ++i)
+	{
+		aInnerPad[i] = aKeyBlock[i] ^ 0x36;
+		aOuterPad[i] = aKeyBlock[i] ^ 0x5c;
+	}
+
+	SHA256_CTX InnerCtx;
+	sha256_init(&InnerCtx);
+	sha256_update(&InnerCtx, aInnerPad.data(), aInnerPad.size());
+	if(DataLength > 0)
+		sha256_update(&InnerCtx, pData, DataLength);
+	const SHA256_DIGEST InnerDigest = sha256_finish(&InnerCtx);
+
+	SHA256_CTX OuterCtx;
+	sha256_init(&OuterCtx);
+	sha256_update(&OuterCtx, aOuterPad.data(), aOuterPad.size());
+	sha256_update(&OuterCtx, InnerDigest.data, sizeof(InnerDigest.data));
+	return sha256_finish(&OuterCtx);
+}
+
+std::string Sha256Hex(const unsigned char *pData, size_t DataLength)
+{
+	char aDigest[SHA256_MAXSTRSIZE];
+	sha256_str(sha256(pData, DataLength), aDigest, sizeof(aDigest));
+	return aDigest;
+}
+
+std::string Sha256Hex(const std::string &Value)
+{
+	return Sha256Hex(reinterpret_cast<const unsigned char *>(Value.data()), Value.size());
+}
+
+std::string HmacSha256Hex(const unsigned char *pKey, size_t KeyLength, const std::string &Value)
+{
+	char aDigest[SHA256_MAXSTRSIZE];
+	const SHA256_DIGEST Digest = HmacSha256(pKey, KeyLength,
+		reinterpret_cast<const unsigned char *>(Value.data()), Value.size());
+	sha256_str(Digest, aDigest, sizeof(aDigest));
+	return aDigest;
+}
+
+std::string HmacSha256Raw(const unsigned char *pKey, size_t KeyLength, const std::string &Value)
+{
+	const SHA256_DIGEST Digest = HmacSha256(pKey, KeyLength,
+		reinterpret_cast<const unsigned char *>(Value.data()), Value.size());
+	return std::string(reinterpret_cast<const char *>(Digest.data), sizeof(Digest.data));
+}
+
+bool FormatUtcDate(int64_t Timestamp, char *pOutDate, size_t OutDateSize)
+{
+	time_t TimeValue = static_cast<time_t>(Timestamp);
+	std::tm UtcTime{};
+#if defined(CONF_FAMILY_WINDOWS)
+	if(gmtime_s(&UtcTime, &TimeValue) != 0)
+		return false;
+#else
+	if(gmtime_r(&TimeValue, &UtcTime) == nullptr)
+		return false;
+#endif
+	return strftime(pOutDate, OutDateSize, "%Y-%m-%d", &UtcTime) > 0;
+}
+
+bool ParseHttpsUrl(const char *pUrl, std::string &Host, std::string &Path, char *pError, size_t ErrorSize)
+{
+	if(!pUrl || pUrl[0] == '\0')
+	{
+		str_copy(pError, "TencentCloud endpoint is empty", ErrorSize);
+		return false;
+	}
+
+	std::string Url = pUrl;
+	const size_t FirstNonWhitespace = Url.find_first_not_of(" \t\r\n");
+	if(FirstNonWhitespace == std::string::npos)
+	{
+		str_copy(pError, "TencentCloud endpoint is empty", ErrorSize);
+		return false;
+	}
+	const size_t LastNonWhitespace = Url.find_last_not_of(" \t\r\n");
+	Url = Url.substr(FirstNonWhitespace, LastNonWhitespace - FirstNonWhitespace + 1);
+
+	const char *pWithoutScheme = str_startswith_nocase(Url.c_str(), "https://");
+	if(!pWithoutScheme)
+	{
+		if(str_startswith_nocase(Url.c_str(), "http://"))
+		{
+			str_copy(pError, "TencentCloud endpoint must use https", ErrorSize);
+			return false;
+		}
+
+		if(str_find(Url.c_str(), "://") != nullptr)
+		{
+			str_copy(pError, "TencentCloud endpoint has unsupported scheme", ErrorSize);
+			return false;
+		}
+
+		// Allow SDK-style endpoints like `tmt.tencentcloudapi.com`.
+		pWithoutScheme = Url.c_str();
+	}
+
+	const char *pPath = str_find(pWithoutScheme, "/");
+	if(pPath)
+	{
+		Host.assign(pWithoutScheme, pPath - pWithoutScheme);
+		Path.assign(pPath);
+	}
+	else
+	{
+		Host.assign(pWithoutScheme);
+		Path = "/";
+	}
+
+	if(Host.empty())
+	{
+		str_copy(pError, "TencentCloud endpoint host is empty", ErrorSize);
+		return false;
+	}
+	if(Path.empty())
+		Path = "/";
+	if(Path.find('?') != std::string::npos)
+	{
+		str_copy(pError, "TencentCloud endpoint must not contain query parameters", ErrorSize);
+		return false;
+	}
+	return true;
+}
+
+bool IsChineseLanguage(const char *pLanguage)
+{
+	if(!pLanguage || pLanguage[0] == '\0')
+		return false;
+	return str_comp_nocase(pLanguage, "zh") == 0 ||
+		str_comp_nocase(pLanguage, "zh-cn") == 0 ||
+		str_comp_nocase(pLanguage, "zh-tw") == 0;
+}
+
+const char *GetTencentCloudSecretId()
+{
+	return TENCENTCLOUD_SECRET_ID_FALLBACK;
+}
+
+const char *GetTencentCloudSecretKey()
+{
+	return TENCENTCLOUD_SECRET_KEY_FALLBACK;
+}
+
+const char *GetEffectiveTranslateTarget(const char *pTarget)
+{
+	return (pTarget && pTarget[0] != '\0') ? pTarget : CConfig::ms_pTcTranslateTarget;
+}
+
+bool IsOutgoingTranslateTargetChar(char Character)
+{
+	const unsigned char Value = static_cast<unsigned char>(Character);
+	return std::isalnum(Value) != 0 || Character == '-' || Character == '_';
+}
+
+bool ParseOutgoingTranslateTarget(const char *pLine, std::string &Text, std::string &Target)
+{
+	if(!pLine)
+		return false;
+
+	const char *pTrimmedLine = str_utf8_skip_whitespaces(pLine);
+	if(*pTrimmedLine == '\0' || *pTrimmedLine == '/')
+		return false;
+
+	std::string Line = pLine;
+	const size_t LastNonWhitespace = Line.find_last_not_of(" \t\r\n");
+	if(LastNonWhitespace == std::string::npos || Line[LastNonWhitespace] != ']')
+		return false;
+
+	const size_t OpenBracket = Line.rfind('[', LastNonWhitespace);
+	if(OpenBracket == std::string::npos || OpenBracket + 1 >= LastNonWhitespace)
+		return false;
+
+	Target = Line.substr(OpenBracket + 1, LastNonWhitespace - OpenBracket - 1);
+	if(Target.size() < 2 || Target.size() >= 16)
+		return false;
+	if(std::any_of(Target.begin(), Target.end(), [](char Character) { return !IsOutgoingTranslateTargetChar(Character); }))
+		return false;
+
+	size_t TextEnd = OpenBracket;
+	while(TextEnd > 0 && std::isspace(static_cast<unsigned char>(Line[TextEnd - 1])) != 0)
+		--TextEnd;
+	if(TextEnd == 0)
+		return false;
+
+	Text = Line.substr(0, TextEnd);
+	return true;
+}
+} // namespace
 
 static void UrlEncode(const char *pText, char *pOut, size_t Length)
 {
@@ -60,8 +283,13 @@ class ITranslateBackendHttp : public ITranslateBackend
 {
 protected:
 	std::shared_ptr<CHttpRequest> m_pHttpRequest = nullptr;
+	char m_aInitError[256] = "";
 	virtual bool ParseResponse(CTranslateResponse &Out) = 0;
 	virtual bool ParseHttpError() const { return false; }
+	void SetInitError(const char *pError)
+	{
+		str_copy(m_aInitError, pError, sizeof(m_aInitError));
+	}
 
 	void CreateHttpRequest(IHttp &Http, const char *pUrl)
 	{
@@ -77,6 +305,11 @@ protected:
 public:
 	std::optional<bool> Update(CTranslateResponse &Out) override
 	{
+		if(m_aInitError[0] != '\0')
+		{
+			str_copy(Out.m_Text, m_aInitError);
+			return false;
+		}
 		dbg_assert(m_pHttpRequest != nullptr, "m_pHttpRequest is nullptr");
 		if(m_pHttpRequest->State() == EHttpState::RUNNING || m_pHttpRequest->State() == EHttpState::QUEUED)
 			return std::nullopt;
@@ -196,7 +429,7 @@ public:
 	{
 		return "LibreTranslate";
 	}
-	CTranslateBackendLibretranslate(IHttp &Http, const char *pText)
+	CTranslateBackendLibretranslate(IHttp &Http, const char *pText, const char *pTarget)
 	{
 		CJsonStringWriter Json = CJsonStringWriter();
 		Json.BeginObject();
@@ -205,7 +438,7 @@ public:
 		Json.WriteAttribute("source");
 		Json.WriteStrValue("auto");
 		Json.WriteAttribute("target");
-		Json.WriteStrValue(EncodeTarget(g_Config.m_TcTranslateTarget));
+		Json.WriteStrValue(EncodeTarget(pTarget));
 		Json.WriteAttribute("format");
 		Json.WriteStrValue("text");
 		if(g_Config.m_TcTranslateKey[0] != '\0')
@@ -217,6 +450,175 @@ public:
 		CreateHttpRequest(Http, g_Config.m_TcTranslateEndpoint[0] == '\0' ? "localhost:5000/translate" : g_Config.m_TcTranslateEndpoint);
 		const char *pJson = Json.GetOutputString().c_str();
 		m_pHttpRequest->PostJson(pJson);
+	}
+};
+
+class CTranslateBackendTencentCloud : public ITranslateBackendHttp
+{
+private:
+	static constexpr const char *CONTENT_TYPE = "application/json; charset=utf-8";
+
+	bool ParseResponseJson(const json_value *pObj, CTranslateResponse &Out)
+	{
+		if(!pObj)
+		{
+			str_copy(Out.m_Text, "Response is not JSON");
+			return false;
+		}
+		if(pObj->type != json_object)
+		{
+			str_copy(Out.m_Text, "Response is not object");
+			return false;
+		}
+
+		const json_value *pResponse = json_object_get(pObj, "Response");
+		if(pResponse == &json_value_none || pResponse->type != json_object)
+		{
+			str_copy(Out.m_Text, "No Response object");
+			return false;
+		}
+
+		const json_value *pError = json_object_get(pResponse, "Error");
+		if(pError != &json_value_none)
+		{
+			const json_value *pCode = json_object_get(pError, "Code");
+			const json_value *pMessage = json_object_get(pError, "Message");
+			const char *pCodeStr = pCode != &json_value_none && pCode->type == json_string ? pCode->u.string.ptr : "UnknownError";
+			const char *pMessageStr = pMessage != &json_value_none && pMessage->type == json_string ? pMessage->u.string.ptr : "TencentCloud request failed";
+			str_format(Out.m_Text, sizeof(Out.m_Text), "%s: %s", pCodeStr, pMessageStr);
+			return false;
+		}
+
+		const json_value *pTranslatedText = json_object_get(pResponse, "TargetText");
+		if(pTranslatedText == &json_value_none)
+		{
+			str_copy(Out.m_Text, "No TargetText");
+			return false;
+		}
+		if(pTranslatedText->type != json_string)
+		{
+			str_copy(Out.m_Text, "TargetText is not string");
+			return false;
+		}
+
+		const json_value *pSource = json_object_get(pResponse, "Source");
+		if(pSource != &json_value_none && pSource->type == json_string)
+			str_copy(Out.m_Language, pSource->u.string.ptr);
+		else
+			Out.m_Language[0] = '\0';
+
+		str_copy(Out.m_Text, pTranslatedText->u.string.ptr);
+		return true;
+	}
+
+protected:
+	bool ParseResponse(CTranslateResponse &Out) override
+	{
+		json_value *pObj = m_pHttpRequest->ResultJson();
+		const bool Result = ParseResponseJson(pObj, Out);
+		json_value_free(pObj);
+		return Result;
+	}
+
+	bool ParseHttpError() const override
+	{
+		return true;
+	}
+
+public:
+	const char *EncodeTarget(const char *pTarget) const override
+	{
+		if(!pTarget || pTarget[0] == '\0')
+			return CConfig::ms_pTcTranslateTarget;
+		if(str_comp_nocase(pTarget, "zh-cn") == 0)
+			return "zh";
+		if(str_comp_nocase(pTarget, "zh-tw") == 0)
+			return "zh-TW";
+		return pTarget;
+	}
+
+	const char *Name() const override
+	{
+		return "TencentCloud";
+	}
+
+	CTranslateBackendTencentCloud(IHttp &Http, const char *pText, const char *pTarget)
+	{
+		const char *pSecretId = GetTencentCloudSecretId();
+		const char *pSecretKey = GetTencentCloudSecretKey();
+		if(!pSecretId || !pSecretId[0] || !pSecretKey || !pSecretKey[0])
+		{
+			SetInitError("Missing TencentCloud credentials: set env vars or tc_translate_secret_id/tc_translate_secret_key");
+			return;
+		}
+
+		const char *pEndpoint = g_Config.m_TcTranslateEndpoint[0] != '\0' ? g_Config.m_TcTranslateEndpoint : TENCENTCLOUD_TMT_DEFAULT_ENDPOINT;
+		std::string Host;
+		std::string Path;
+		if(!ParseHttpsUrl(pEndpoint, Host, Path, m_aInitError, sizeof(m_aInitError)))
+			return;
+		const std::string RequestUrl = "https://" + Host + Path;
+
+		CJsonStringWriter Json;
+		Json.BeginObject();
+		Json.WriteAttribute("ProjectId");
+		Json.WriteIntValue(0);
+		Json.WriteAttribute("Source");
+		Json.WriteStrValue("auto");
+		Json.WriteAttribute("SourceText");
+		Json.WriteStrValue(pText);
+		Json.WriteAttribute("Target");
+		Json.WriteStrValue(EncodeTarget(pTarget));
+		Json.EndObject();
+		const std::string Payload = Json.GetOutputString();
+
+		const int64_t Timestamp = time_timestamp();
+		char aDate[32];
+		if(!FormatUtcDate(Timestamp, aDate, sizeof(aDate)))
+		{
+			SetInitError("Failed to format TencentCloud request date");
+			return;
+		}
+
+		const std::string CanonicalHeaders =
+			std::string("content-type:") + CONTENT_TYPE + "\n"
+			"host:" + Host + "\n";
+		const std::string SignedHeaders = "content-type;host";
+		const std::string CanonicalRequest =
+			"POST\n" + Path + "\n\n" + CanonicalHeaders + "\n" + SignedHeaders + "\n" + Sha256Hex(Payload);
+		const std::string CredentialScope = std::string(aDate) + "/" + TENCENTCLOUD_TMT_SERVICE + "/tc3_request";
+		const std::string TimestampString = std::to_string(Timestamp);
+		const std::string StringToSign =
+			"TC3-HMAC-SHA256\n" + TimestampString + "\n" + CredentialScope + "\n" + Sha256Hex(CanonicalRequest);
+
+		const std::string SecretPrefix = std::string("TC3") + pSecretKey;
+		const std::string SecretDate = HmacSha256Raw(
+			reinterpret_cast<const unsigned char *>(SecretPrefix.data()), SecretPrefix.size(), aDate);
+		const std::string SecretService = HmacSha256Raw(
+			reinterpret_cast<const unsigned char *>(SecretDate.data()), SecretDate.size(), TENCENTCLOUD_TMT_SERVICE);
+		const std::string SecretSigning = HmacSha256Raw(
+			reinterpret_cast<const unsigned char *>(SecretService.data()), SecretService.size(), "tc3_request");
+		const std::string Signature = HmacSha256Hex(
+			reinterpret_cast<const unsigned char *>(SecretSigning.data()), SecretSigning.size(), StringToSign);
+
+		const std::string Authorization =
+			"TC3-HMAC-SHA256 Credential=" + std::string(pSecretId) + "/" + CredentialScope +
+			", SignedHeaders=" + SignedHeaders +
+			", Signature=" + Signature;
+
+		m_pHttpRequest = std::make_shared<CHttpRequest>(RequestUrl.c_str());
+		m_pHttpRequest->LogProgress(HTTPLOG::FAILURE);
+		m_pHttpRequest->FailOnErrorStatus(false);
+		m_pHttpRequest->Timeout(CTimeout{10000, 0, 500, 10});
+		m_pHttpRequest->HeaderString("Content-Type", CONTENT_TYPE);
+		m_pHttpRequest->HeaderString("Authorization", Authorization.c_str());
+		m_pHttpRequest->HeaderString("Host", Host.c_str());
+		m_pHttpRequest->HeaderString("X-TC-Action", TENCENTCLOUD_TMT_ACTION);
+		m_pHttpRequest->HeaderString("X-TC-Version", TENCENTCLOUD_TMT_VERSION);
+		m_pHttpRequest->HeaderString("X-TC-Region", g_Config.m_TcTranslateRegion);
+		m_pHttpRequest->HeaderString("X-TC-Timestamp", TimestampString.c_str());
+		m_pHttpRequest->Post(reinterpret_cast<const unsigned char *>(Payload.data()), Payload.size());
+		Http.Run(m_pHttpRequest);
 	}
 };
 
@@ -289,18 +691,29 @@ public:
 	{
 		return "FreeTranslateAPI";
 	}
-	CTranslateBackendFtapi(IHttp &Http, const char *pText)
+	CTranslateBackendFtapi(IHttp &Http, const char *pText, const char *pTarget)
 	{
 		char aBuf[4096];
 		str_format(aBuf, sizeof(aBuf), "%s/translate?dl=%s&text=",
 			g_Config.m_TcTranslateEndpoint[0] != '\0' ? g_Config.m_TcTranslateEndpoint : "https://ftapi.pythonanywhere.com",
-			EncodeTarget(g_Config.m_TcTranslateTarget));
+			EncodeTarget(pTarget));
 
 		UrlEncode(pText, aBuf + strlen(aBuf), sizeof(aBuf) - strlen(aBuf));
 
 		CreateHttpRequest(Http, aBuf);
 	}
 };
+
+static std::unique_ptr<ITranslateBackend> CreateTranslateBackend(IHttp &Http, const char *pText, const char *pTarget)
+{
+	if(str_comp_nocase(g_Config.m_TcTranslateBackend, "libretranslate") == 0)
+		return std::make_unique<CTranslateBackendLibretranslate>(Http, pText, pTarget);
+	if(str_comp_nocase(g_Config.m_TcTranslateBackend, "ftapi") == 0)
+		return std::make_unique<CTranslateBackendFtapi>(Http, pText, pTarget);
+	if(str_comp_nocase(g_Config.m_TcTranslateBackend, "tencentcloud") == 0)
+		return std::make_unique<CTranslateBackendTencentCloud>(Http, pText, pTarget);
+	return nullptr;
+}
 
 void CTranslate::ConTranslate(IConsole::IResult *pResult, void *pUserData)
 {
@@ -386,23 +799,27 @@ void CTranslate::Translate(const char *pName, bool ShowProgress)
 	Translate(*pLineBest, ShowProgress);
 }
 
-void CTranslate::Translate(CChat::CLine &Line, bool ShowProgress)
+void CTranslate::Translate(CChat::CLine &Line, bool ShowProgress, bool AutoTriggered)
 {
 	if(m_vJobs.size() > 15)
 	{
+		return;
+	}
+	if(Line.m_ClientId == CChat::SERVER_MSG)
+	{
+		if(ShowProgress)
+			GameClient()->m_Chat.Echo("Server messages are not translated");
 		return;
 	}
 
 	CTranslateJob Job;
 	Job.m_pLine = &Line;
 	Job.m_pTranslateResponse = std::make_shared<CTranslateResponse>();
+	Job.m_AutoTriggered = AutoTriggered;
 	Job.m_pLine->m_pTranslateResponse = Job.m_pTranslateResponse;
-
-	if(str_comp_nocase(g_Config.m_TcTranslateBackend, "libretranslate") == 0)
-		Job.m_pBackend = std::make_unique<CTranslateBackendLibretranslate>(*Http(), Job.m_pLine->m_aText);
-	else if(str_comp_nocase(g_Config.m_TcTranslateBackend, "ftapi") == 0)
-		Job.m_pBackend = std::make_unique<CTranslateBackendFtapi>(*Http(), Job.m_pLine->m_aText);
-	else
+	str_copy(Job.m_aTarget, GetEffectiveTranslateTarget(g_Config.m_TcTranslateTarget), sizeof(Job.m_aTarget));
+	Job.m_pBackend = CreateTranslateBackend(*Http(), Job.m_pLine->m_aText, Job.m_aTarget);
+	if(!Job.m_pBackend)
 	{
 		GameClient()->m_Chat.Echo("Invalid translate backend");
 		return;
@@ -410,7 +827,7 @@ void CTranslate::Translate(CChat::CLine &Line, bool ShowProgress)
 
 	if(ShowProgress)
 	{
-		str_format(Job.m_pTranslateResponse->m_Text, sizeof(Job.m_pTranslateResponse->m_Text), TCLocalize("%s translating to %s", "translate"), Job.m_pBackend->Name(), g_Config.m_TcTranslateTarget);
+		str_format(Job.m_pTranslateResponse->m_Text, sizeof(Job.m_pTranslateResponse->m_Text), TCLocalize("%s translating to %s", "translate"), Job.m_pBackend->Name(), Job.m_aTarget);
 		Job.m_pLine->m_Time = time();
 	}
 	else
@@ -424,6 +841,36 @@ void CTranslate::Translate(CChat::CLine &Line, bool ShowProgress)
 		GameClient()->m_Chat.RebuildChat();
 }
 
+bool CTranslate::TryTranslateOutgoingChat(int Team, const char *pText)
+{
+	std::string Text;
+	std::string Target;
+	if(!ParseOutgoingTranslateTarget(pText, Text, Target))
+		return false;
+
+	if(m_vJobs.size() + m_vOutgoingJobs.size() > 15)
+	{
+		GameClient()->m_Chat.Echo("Too many translation jobs");
+		return true;
+	}
+
+	COutgoingTranslateJob Job;
+	Job.m_Team = Team;
+	str_copy(Job.m_aTarget, Target.c_str(), sizeof(Job.m_aTarget));
+	Job.m_pBackend = CreateTranslateBackend(*Http(), Text.c_str(), Job.m_aTarget);
+	if(!Job.m_pBackend)
+	{
+		GameClient()->m_Chat.Echo("Invalid translate backend");
+		return true;
+	}
+
+	char aBuf[128];
+	str_format(aBuf, sizeof(aBuf), "%s translating to %s before send", Job.m_pBackend->Name(), Job.m_aTarget);
+	GameClient()->m_Chat.Echo(aBuf);
+	m_vOutgoingJobs.emplace_back(std::move(Job));
+	return true;
+}
+
 void CTranslate::OnRender()
 {
 	const auto Time = time();
@@ -435,13 +882,15 @@ void CTranslate::OnRender()
 			return false; // Keep ongoing tasks
 		if(*Done)
 		{
-			if(str_comp_nocase(Job.m_pLine->m_aText, Job.m_pTranslateResponse->m_Text) == 0) // Check for no translation difference
+			if(Job.m_AutoTriggered && IsChineseLanguage(Job.m_pTranslateResponse->m_Language))
+				Job.m_pTranslateResponse->m_Text[0] = '\0';
+			else if(str_comp_nocase(Job.m_pLine->m_aText, Job.m_pTranslateResponse->m_Text) == 0) // Check for no translation difference
 				Job.m_pTranslateResponse->m_Text[0] = '\0';
 		}
 		else
 		{
 			char aBuf[sizeof(Job.m_pTranslateResponse->m_Text)];
-			str_format(aBuf, sizeof(aBuf), TCLocalize("%s to %s failed: %s", "translate"), Job.m_pBackend->Name(), g_Config.m_TcTranslateTarget, Job.m_pTranslateResponse->m_Text);
+			str_format(aBuf, sizeof(aBuf), TCLocalize("%s to %s failed: %s", "translate"), Job.m_pBackend->Name(), Job.m_aTarget, Job.m_pTranslateResponse->m_Text);
 			Job.m_pTranslateResponse->m_Error = true;
 			str_copy(Job.m_pTranslateResponse->m_Text, aBuf);
 		}
@@ -450,6 +899,33 @@ void CTranslate::OnRender()
 		return true;
 	};
 	m_vJobs.erase(std::remove_if(m_vJobs.begin(), m_vJobs.end(), ForEach), m_vJobs.end());
+
+	auto ForEachOutgoing = [&](COutgoingTranslateJob &Job) {
+		const std::optional<bool> Done = Job.m_pBackend->Update(Job.m_Response);
+		if(!Done.has_value())
+			return false;
+		if(*Done)
+		{
+			if(Job.m_Response.m_Text[0] == '\0')
+			{
+				char aBuf[sizeof(Job.m_Response.m_Text)];
+				str_format(aBuf, sizeof(aBuf), "%s to %s failed: Empty translation result", Job.m_pBackend->Name(), Job.m_aTarget);
+				GameClient()->m_Chat.Echo(aBuf);
+			}
+			else
+			{
+				GameClient()->m_Chat.SendChatQueued(Job.m_Team, Job.m_Response.m_Text, false);
+			}
+		}
+		else
+		{
+			char aBuf[sizeof(Job.m_Response.m_Text)];
+			str_format(aBuf, sizeof(aBuf), "%s to %s failed: %s", Job.m_pBackend->Name(), Job.m_aTarget, Job.m_Response.m_Text);
+			GameClient()->m_Chat.Echo(aBuf);
+		}
+		return true;
+	};
+	m_vOutgoingJobs.erase(std::remove_if(m_vOutgoingJobs.begin(), m_vOutgoingJobs.end(), ForEachOutgoing), m_vOutgoingJobs.end());
 }
 
 void CTranslate::AutoTranslate(CChat::CLine &Line)
@@ -457,6 +933,8 @@ void CTranslate::AutoTranslate(CChat::CLine &Line)
 	if(!g_Config.m_TcTranslateAuto)
 		return;
 	if(Line.m_ClientId == CChat::CLIENT_MSG)
+		return;
+	if(Line.m_ClientId == CChat::SERVER_MSG)
 		return;
 	for(const int Id : GameClient()->m_aLocalIds)
 	{
@@ -469,5 +947,5 @@ void CTranslate::AutoTranslate(CChat::CLine &Line)
 		// It may shut down if we spam it too hard
 		return;
 	}
-	Translate(Line, false);
+	Translate(Line, false, true);
 }

--- a/src/game/client/components/qmclient/translate.h
+++ b/src/game/client/components/qmclient/translate.h
@@ -29,8 +29,20 @@ class CTranslate : public CComponent
 		// For chat translations
 		CChat::CLine *m_pLine = nullptr;
 		std::shared_ptr<CTranslateResponse> m_pTranslateResponse = nullptr;
+		bool m_AutoTriggered = false;
+		char m_aTarget[16] = "";
 	};
 	std::vector<CTranslateJob> m_vJobs;
+
+	class COutgoingTranslateJob
+	{
+	public:
+		std::unique_ptr<ITranslateBackend> m_pBackend = nullptr;
+		CTranslateResponse m_Response;
+		int m_Team = 0;
+		char m_aTarget[16] = "";
+	};
+	std::vector<COutgoingTranslateJob> m_vOutgoingJobs;
 
 	static void ConTranslate(IConsole::IResult *pResult, void *pUserData);
 	static void ConTranslateId(IConsole::IResult *pResult, void *pUserData);
@@ -43,7 +55,8 @@ public:
 
 	void Translate(int Id, bool ShowProgress = true);
 	void Translate(const char *pName, bool ShowProgress = true);
-	void Translate(CChat::CLine &Line, bool ShowProgress = true);
+	void Translate(CChat::CLine &Line, bool ShowProgress = true, bool AutoTriggered = false);
+	bool TryTranslateOutgoingChat(int Team, const char *pText);
 
 	void AutoTranslate(CChat::CLine &Line);
 };


### PR DESCRIPTION
## FEAT
- 新增 TencentCloud 翻译后端，支持 TC3-HMAC-SHA256 签名请求，并按目标语言动态发起翻译。
- 新增聊天消息发送前翻译能力，支持从输入内容中解析目标语言后再异步翻译并发送。
- 新增翻译后端统一创建入口，便于在 libretranslate、ftapi、tencentcloud 之间切换。
- 新增纹理句柄 generation 机制，用于识别句柄复用后的过期状态，提升图形资源管理安全性。
## FIX

- 修复纹理句柄复用后可能出现的重复释放、重复卸载、错误绑定和错误更新问题，避免使用 stale handle。
- 修复文本纹理释放流程，统一走通用纹理卸载逻辑，减少资源释放不一致问题。
- 修复素材工坊资源解析逻辑，兼容新旧接口结构和不同分类命名。
- 修复素材图片地址解析，过滤变换后缀，避免无效资源链接导致加载异常。
- 修复自定义素材清理时的纹理释放逻辑，避免实体纹理残留或重复释放。
- 修复工坊请求状态提示，补充 aborted、非 200 响应、JSON 解析失败等错误反馈。
- 修复翻译流程对服务器消息的处理，避免对服务器消息执行翻译。
- 修复自动翻译场景下中文结果的处理，避免无意义覆盖或重复展示。
- 修复翻译提示文案，失败和进度提示改为使用实际目标语言而不是固定配置值。
## DEL

- 移除对旧 3gqy.cn 分类接口地址的直接依赖，统一改为 https://www.ddrace.cn/data/assets.json 数据源。
- 移除文本纹理专用销毁命令的直接调用方式，改为统一复用 UnloadTexture 流程。
- 去掉部分依赖断言式中断的纹理释放逻辑，改为安全忽略并记录过期句柄。