### PR TITLE
FEAT - 资源页面优化、WebP 支持、实体层预览及汉化更新

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -561,6 +561,7 @@ find_package(Opus)
 find_package(Opusfile)
 find_package(PNG)
 find_package(Python3)
+find_package(WebP)
 find_package(Rust)
 find_package(SDL2)
 find_package(SQLite3)
@@ -657,6 +658,7 @@ show_dependency_status("Python3" Python3)
 show_dependency_status("SDL2" SDL2)
 show_dependency_status("SQLite3" SQLite3)
 show_dependency_status("Wavpack" WAVPACK)
+show_dependency_status("WebP" WebP)
 show_dependency_status("Zlib" ZLIB)
 if(DISCORD)
   show_dependency_status("DiscordSdk" DiscordSdk)
@@ -2007,6 +2009,7 @@ set(COPY_FILES
   ${WEBSOCKETS_COPY_FILES}
   ${DISCORDSDK_COPY_FILES}
   ${VULKAN_COPY_FILES}
+  ${WebP_COPY_FILES}
   ${CRASHDUMP_COPY_FILES}
   ${SSP_COPY_FILES}
 )
@@ -2369,6 +2372,12 @@ set(LIBS
 # Targets
 add_library(engine-gfx EXCLUDE_FROM_ALL OBJECT ${ENGINE_GFX})
 target_include_directories(engine-gfx PRIVATE ${PNG_INCLUDE_DIRS})
+if(WebP_FOUND)
+  target_include_directories(engine-gfx PRIVATE ${WebP_INCLUDE_DIRS})
+endif()
+if(VIDEORECORDER AND FFMPEG_FOUND)
+  target_include_directories(engine-gfx PRIVATE ${FFMPEG_INCLUDE_DIRS})
+endif()
 add_library(engine-shared EXCLUDE_FROM_ALL OBJECT ${ENGINE_EXTERNAL} ${ENGINE_INTERFACE} ${ENGINE_SHARED} ${ENGINE_UUID_SHARED} ${BASE})
 add_library(game-shared EXCLUDE_FROM_ALL OBJECT ${GAME_SHARED} ${GAME_GENERATED_SHARED})
 list(APPEND TARGETS_OWN engine-gfx engine-shared game-shared)
@@ -2815,6 +2824,7 @@ if(CLIENT)
     ${SDL2_LIBRARIES}
     ${WAVPACK_LIBRARIES}
     ${FFMPEG_LIBRARIES}
+    ${WebP_LIBRARIES}
 
     # Order of these three is important.
     ${OPUSFILE_LIBRARIES}
@@ -2917,6 +2927,7 @@ if(CLIENT)
     ${SDL2_INCLUDE_DIRS}
     ${WAVPACK_INCLUDE_DIRS}
     ${FFMPEG_INCLUDE_DIRS}
+    ${WebP_INCLUDE_DIRS}
     ${DISCORDSDK_INCLUDE_DIRS}
 
     ${VULKAN_INCLUDE_DIRS}

--- a/cmake/FindWebP.cmake
+++ b/cmake/FindWebP.cmake
@@ -1,0 +1,40 @@
+if(NOT PREFER_BUNDLED_LIBS)
+  set(CMAKE_MODULE_PATH ${ORIGINAL_CMAKE_MODULE_PATH})
+  find_package(WebP)
+  set(CMAKE_MODULE_PATH ${OWN_CMAKE_MODULE_PATH})
+  if(WebP_FOUND)
+    set(WebP_BUNDLED OFF)
+    set(WebP_DEP)
+  endif()
+endif()
+
+if(NOT WebP_FOUND)
+  set_extra_dirs_lib(WebP webp)
+  find_library(WebP_LIBRARY
+    NAMES webp libwebp
+    HINTS ${HINTS_WebP_LIBDIR} ${PC_WebP_LIBDIR} ${PC_WebP_LIBRARY_DIRS}
+    PATHS ${PATHS_WebP_LIBDIR}
+    ${CROSSCOMPILING_NO_CMAKE_SYSTEM_PATH}
+  )
+
+  set_extra_dirs_include(WebP webp "${WebP_LIBRARY}")
+  find_path(WebP_INCLUDEDIR
+    NAMES webp/decode.h
+    HINTS ${HINTS_WebP_INCLUDEDIR} ${PC_WebP_INCLUDEDIR} ${PC_WebP_INCLUDE_DIRS}
+    PATHS ${PATHS_WebP_INCLUDEDIR}
+    ${CROSSCOMPILING_NO_CMAKE_SYSTEM_PATH}
+  )
+
+  mark_as_advanced(WebP_LIBRARY WebP_INCLUDEDIR)
+
+  if(WebP_LIBRARY AND WebP_INCLUDEDIR)
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(WebP DEFAULT_MSG WebP_LIBRARY WebP_INCLUDEDIR)
+
+    set(WebP_LIBRARIES ${WebP_LIBRARY})
+    set(WebP_INCLUDE_DIRS ${WebP_INCLUDEDIR})
+  endif()
+endif()
+
+set(WebP_COPY_FILES)
+# WebP on Windows uses static library, no DLL to copy

--- a/data/languages/simplified_chinese.txt
+++ b/data/languages/simplified_chinese.txt
@@ -340,6 +340,9 @@ Score limit
 Scoreboard
 == 计分板
 
+Scoreboard cursor
+== 计分板光标
+
 Screenshot
 == 截图
 

--- a/data/qmclient/languages/simplified_chinese.txt
+++ b/data/qmclient/languages/simplified_chinese.txt
@@ -1010,3 +1010,15 @@ Misc
 
 Auto
 == 自动
+
+Entity Preview
+== 实体层预览
+
+Toggle between game scene preview and raw texture
+== 在游戏场景预览和原始材质之间切换
+
+Are you sure you want to delete this asset?
+== 确定要删除此资源吗？
+
+Download this asset?
+== 确定要下载此资源吗？

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -497,6 +497,7 @@ IGraphics::CTextureHandle CGraphics_Threaded::LoadTexture(const char *pFilename,
 	dbg_assert(pFilename[0] != '\0', "Cannot load texture from file with empty filename"); // would cause Valgrind to crash otherwise
 
 	CImageInfo Image;
+	// Try PNG first
 	if(LoadPng(Image, pFilename, StorageType))
 	{
 		CTextureHandle Id = LoadTextureRawMove(Image, Flags, pFilename);
@@ -504,6 +505,18 @@ IGraphics::CTextureHandle CGraphics_Threaded::LoadTexture(const char *pFilename,
 		{
 			if(g_Config.m_Debug)
 				log_trace("graphics/texture", "Loaded texture '%s'", pFilename);
+			return Id;
+		}
+	}
+
+	// Try WebP if PNG failed
+	if(LoadWebp(Image, pFilename, StorageType))
+	{
+		CTextureHandle Id = LoadTextureRawMove(Image, Flags, pFilename);
+		if(Id.IsValid())
+		{
+			if(g_Config.m_Debug)
+				log_trace("graphics/texture", "Loaded WebP texture '%s'", pFilename);
 			return Id;
 		}
 	}
@@ -660,6 +673,21 @@ bool CGraphics_Threaded::LoadPng(CImageInfo &Image, const uint8_t *pData, size_t
 	}
 
 	return true;
+}
+
+bool CGraphics_Threaded::LoadWebp(CImageInfo &Image, const char *pFilename, int StorageType)
+{
+	IOHANDLE File = m_pStorage->OpenFile(pFilename, IOFLAG_READ, StorageType);
+	if(!File)
+		return false;
+
+	return CImageLoader::LoadWebp(File, pFilename, Image);
+}
+
+bool CGraphics_Threaded::LoadWebp(CImageInfo &Image, const uint8_t *pData, size_t DataSize, const char *pContextName)
+{
+	CByteBufferReader Reader(pData, DataSize);
+	return CImageLoader::LoadWebp(Reader, pContextName, Image);
 }
 
 bool CGraphics_Threaded::CheckImageDivisibility(const char *pContextName, CImageInfo &Image, int DivX, int DivY, bool AllowResize)

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -510,7 +510,7 @@ IGraphics::CTextureHandle CGraphics_Threaded::LoadTexture(const char *pFilename,
 	}
 
 	// Try WebP if PNG failed
-	if(LoadWebp(Image, pFilename, StorageType))
+	if(LoadWebP(Image, pFilename, StorageType))
 	{
 		CTextureHandle Id = LoadTextureRawMove(Image, Flags, pFilename);
 		if(Id.IsValid())
@@ -675,19 +675,19 @@ bool CGraphics_Threaded::LoadPng(CImageInfo &Image, const uint8_t *pData, size_t
 	return true;
 }
 
-bool CGraphics_Threaded::LoadWebp(CImageInfo &Image, const char *pFilename, int StorageType)
+bool CGraphics_Threaded::LoadWebP(CImageInfo &Image, const char *pFilename, int StorageType)
 {
 	IOHANDLE File = m_pStorage->OpenFile(pFilename, IOFLAG_READ, StorageType);
 	if(!File)
 		return false;
 
-	return CImageLoader::LoadWebp(File, pFilename, Image);
+	return CImageLoader::LoadWebP(File, pFilename, Image);
 }
 
-bool CGraphics_Threaded::LoadWebp(CImageInfo &Image, const uint8_t *pData, size_t DataSize, const char *pContextName)
+bool CGraphics_Threaded::LoadWebP(CImageInfo &Image, const uint8_t *pData, size_t DataSize, const char *pContextName)
 {
 	CByteBufferReader Reader(pData, DataSize);
-	return CImageLoader::LoadWebp(Reader, pContextName, Image);
+	return CImageLoader::LoadWebP(Reader, pContextName, Image);
 }
 
 bool CGraphics_Threaded::CheckImageDivisibility(const char *pContextName, CImageInfo &Image, int DivX, int DivY, bool AllowResize)

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -965,6 +965,8 @@ public:
 	IGraphics::CTextureHandle LoadTexture(const char *pFilename, int StorageType, int Flags = 0) override;
 	bool LoadPng(CImageInfo &Image, const char *pFilename, int StorageType) override;
 	bool LoadPng(CImageInfo &Image, const uint8_t *pData, size_t DataSize, const char *pContextName) override;
+	bool LoadWebp(CImageInfo &Image, const char *pFilename, int StorageType);
+	bool LoadWebp(CImageInfo &Image, const uint8_t *pData, size_t DataSize, const char *pContextName);
 
 	bool CheckImageDivisibility(const char *pContextName, CImageInfo &Image, int DivX, int DivY, bool AllowResize) override;
 	bool IsImageFormatRgba(const char *pContextName, const CImageInfo &Image) override;

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -965,8 +965,8 @@ public:
 	IGraphics::CTextureHandle LoadTexture(const char *pFilename, int StorageType, int Flags = 0) override;
 	bool LoadPng(CImageInfo &Image, const char *pFilename, int StorageType) override;
 	bool LoadPng(CImageInfo &Image, const uint8_t *pData, size_t DataSize, const char *pContextName) override;
-	bool LoadWebp(CImageInfo &Image, const char *pFilename, int StorageType);
-	bool LoadWebp(CImageInfo &Image, const uint8_t *pData, size_t DataSize, const char *pContextName);
+	bool LoadWebP(CImageInfo &Image, const char *pFilename, int StorageType);
+	bool LoadWebP(CImageInfo &Image, const uint8_t *pData, size_t DataSize, const char *pContextName);
 
 	bool CheckImageDivisibility(const char *pContextName, CImageInfo &Image, int DivX, int DivY, bool AllowResize) override;
 	bool IsImageFormatRgba(const char *pContextName, const CImageInfo &Image) override;

--- a/src/engine/font_icons.h
+++ b/src/engine/font_icons.h
@@ -1,0 +1,6 @@
+#ifndef ENGINE_FONT_ICONS_H
+#define ENGINE_FONT_ICONS_H
+
+#include <engine/textrender.h>
+
+#endif

--- a/src/engine/gfx/image_loader.cpp
+++ b/src/engine/gfx/image_loader.cpp
@@ -6,14 +6,6 @@
 #include <png.h>
 #include <webp/decode.h>
 
-extern "C" {
-#include <libavcodec/avcodec.h>
-#include <libavformat/avformat.h>
-#include <libavutil/imgutils.h>
-#include <libavutil/error.h>
-#include <libswscale/swscale.h>
-}
-
 #include <csetjmp>
 #include <cstdlib>
 #include <vector>
@@ -418,7 +410,7 @@ bool CImageLoader::SavePng(IOHANDLE File, const char *pFilename, const CImageInf
 	return WriteSuccess;
 }
 
-bool CImageLoader::LoadWebp(CByteBufferReader &Reader, const char *pContextName, CImageInfo &Image)
+bool CImageLoader::LoadWebP(CByteBufferReader &Reader, const char *pContextName, CImageInfo &Image)
 {
 	// Read all data from reader
 	const size_t DataSize = Reader.Size();
@@ -481,7 +473,7 @@ bool CImageLoader::LoadWebp(CByteBufferReader &Reader, const char *pContextName,
 	return true;
 }
 
-bool CImageLoader::LoadWebp(IOHANDLE File, const char *pFilename, CImageInfo &Image)
+bool CImageLoader::LoadWebP(IOHANDLE File, const char *pFilename, CImageInfo &Image)
 {
 	if(!File)
 	{
@@ -501,7 +493,7 @@ bool CImageLoader::LoadWebp(IOHANDLE File, const char *pFilename, CImageInfo &Im
 
 	CByteBufferReader ImageReader(static_cast<const uint8_t *>(pFileData), FileDataSize);
 
-	const bool LoadResult = CImageLoader::LoadWebp(ImageReader, pFilename, Image);
+	const bool LoadResult = CImageLoader::LoadWebP(ImageReader, pFilename, Image);
 	free(pFileData);
 	if(!LoadResult)
 	{
@@ -519,8 +511,8 @@ bool CImageLoader::LoadPng(const void *pData, size_t Size, const char *pContextN
 	return LoadPng(Reader, pContextName, Image, PngliteIncompatible);
 }
 
-bool CImageLoader::LoadWebp(const void *pData, size_t Size, const char *pContextName, CImageInfo &Image)
+bool CImageLoader::LoadWebP(const void *pData, size_t Size, const char *pContextName, CImageInfo &Image)
 {
 	CByteBufferReader Reader(static_cast<const uint8_t *>(pData), Size);
-	return LoadWebp(Reader, pContextName, Image);
+	return LoadWebP(Reader, pContextName, Image);
 }

--- a/src/engine/gfx/image_loader.cpp
+++ b/src/engine/gfx/image_loader.cpp
@@ -4,9 +4,19 @@
 #include <base/system.h>
 
 #include <png.h>
+#include <webp/decode.h>
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavutil/imgutils.h>
+#include <libavutil/error.h>
+#include <libswscale/swscale.h>
+}
 
 #include <csetjmp>
 #include <cstdlib>
+#include <vector>
 
 bool CByteBufferReader::Read(void *pData, size_t Size)
 {
@@ -406,4 +416,111 @@ bool CImageLoader::SavePng(IOHANDLE File, const char *pFilename, const CImageInf
 	}
 	io_close(File);
 	return WriteSuccess;
+}
+
+bool CImageLoader::LoadWebp(CByteBufferReader &Reader, const char *pContextName, CImageInfo &Image)
+{
+	// Read all data from reader
+	const size_t DataSize = Reader.Size();
+	if(DataSize == 0)
+	{
+		log_error("webp", "empty data for '%s'", pContextName);
+		return false;
+	}
+
+	std::vector<uint8_t> vData(DataSize);
+	if(!Reader.Read(vData.data(), DataSize))
+	{
+		log_error("webp", "failed to read data for '%s'", pContextName);
+		return false;
+	}
+
+	// Use libwebp to decode WebP
+	int Width = 0, Height = 0;
+	
+	// First check if it's a valid WebP file and get dimensions
+	if(!WebPGetInfo(vData.data(), vData.size(), &Width, &Height))
+	{
+		log_error("webp", "invalid WebP data for '%s'", pContextName);
+		return false;
+	}
+
+	if(Width == 0 || Height == 0)
+	{
+		log_error("webp", "invalid image dimensions for '%s': %dx%d", pContextName, Width, Height);
+		return false;
+	}
+
+	// Decode to RGBA
+	uint8_t *pDecodedData = WebPDecodeRGBA(vData.data(), vData.size(), &Width, &Height);
+	if(!pDecodedData)
+	{
+		log_error("webp", "failed to decode WebP for '%s'", pContextName);
+		return false;
+	}
+
+	// Allocate output buffer and copy data (libwebp uses its own allocator)
+	const size_t DataSizeOut = Width * Height * 4;
+	uint8_t *pDestData = (uint8_t *)malloc(DataSizeOut);
+	if(!pDestData)
+	{
+		log_error("webp", "failed to allocate output buffer for '%s'", pContextName);
+		WebPFree(pDecodedData);
+		return false;
+	}
+
+	mem_copy(pDestData, pDecodedData, DataSizeOut);
+	WebPFree(pDecodedData);
+
+	// Fill image info
+	Image.m_Width = Width;
+	Image.m_Height = Height;
+	Image.m_Format = CImageInfo::FORMAT_RGBA;
+	Image.m_pData = pDestData;
+
+	return true;
+}
+
+bool CImageLoader::LoadWebp(IOHANDLE File, const char *pFilename, CImageInfo &Image)
+{
+	if(!File)
+	{
+		log_error("webp", "failed to open file for reading. filename='%s'", pFilename);
+		return false;
+	}
+
+	void *pFileData;
+	unsigned FileDataSize;
+	const bool ReadSuccess = io_read_all(File, &pFileData, &FileDataSize);
+	io_close(File);
+	if(!ReadSuccess)
+	{
+		log_error("webp", "failed to read file. filename='%s'", pFilename);
+		return false;
+	}
+
+	CByteBufferReader ImageReader(static_cast<const uint8_t *>(pFileData), FileDataSize);
+
+	const bool LoadResult = CImageLoader::LoadWebp(ImageReader, pFilename, Image);
+	free(pFileData);
+	if(!LoadResult)
+	{
+		log_error("webp", "failed to load image from file. filename='%s'", pFilename);
+		return false;
+	}
+
+	return true;
+}
+
+bool CImageLoader::LoadPng(const void *pData, size_t Size, const char *pContextName, CImageInfo &Image)
+{
+	CByteBufferReader Reader(static_cast<const uint8_t *>(pData), Size);
+	int PngliteIncompatible = 0;
+	return LoadPng(Reader, pContextName, Image, PngliteIncompatible);
+}
+
+bool CImageLoader::LoadWebp(const void *pData, size_t Size, const char *pContextName, CImageInfo &Image)
+{
+	CByteBufferReader Reader(static_cast<const uint8_t *>(pData), Size);
+	return LoadWebp(Reader, pContextName, Image);
 }

--- a/src/engine/gfx/image_loader.h
+++ b/src/engine/gfx/image_loader.h
@@ -21,6 +21,7 @@ public:
 
 	bool Read(void *pData, size_t Size);
 	bool Error() const { return m_Error; }
+	size_t Size() const { return m_Size; }
 };
 
 class CByteBufferWriter
@@ -49,6 +50,11 @@ public:
 
 	static bool LoadPng(CByteBufferReader &Reader, const char *pContextName, CImageInfo &Image, int &PngliteIncompatible);
 	static bool LoadPng(IOHANDLE File, const char *pFilename, CImageInfo &Image, int &PngliteIncompatible);
+	static bool LoadPng(const void *pData, size_t Size, const char *pContextName, CImageInfo &Image);
+
+	static bool LoadWebp(CByteBufferReader &Reader, const char *pContextName, CImageInfo &Image);
+	static bool LoadWebp(IOHANDLE File, const char *pFilename, CImageInfo &Image);
+	static bool LoadWebp(const void *pData, size_t Size, const char *pContextName, CImageInfo &Image);
 
 	static bool SavePng(CByteBufferWriter &Writer, const CImageInfo &Image);
 	static bool SavePng(IOHANDLE File, const char *pFilename, const CImageInfo &Image);

--- a/src/engine/gfx/image_loader.h
+++ b/src/engine/gfx/image_loader.h
@@ -52,9 +52,9 @@ public:
 	static bool LoadPng(IOHANDLE File, const char *pFilename, CImageInfo &Image, int &PngliteIncompatible);
 	static bool LoadPng(const void *pData, size_t Size, const char *pContextName, CImageInfo &Image);
 
-	static bool LoadWebp(CByteBufferReader &Reader, const char *pContextName, CImageInfo &Image);
-	static bool LoadWebp(IOHANDLE File, const char *pFilename, CImageInfo &Image);
-	static bool LoadWebp(const void *pData, size_t Size, const char *pContextName, CImageInfo &Image);
+	static bool LoadWebP(CByteBufferReader &Reader, const char *pContextName, CImageInfo &Image);
+	static bool LoadWebP(IOHANDLE File, const char *pFilename, CImageInfo &Image);
+	static bool LoadWebP(const void *pData, size_t Size, const char *pContextName, CImageInfo &Image);
 
 	static bool SavePng(CByteBufferWriter &Writer, const CImageInfo &Image);
 	static bool SavePng(IOHANDLE File, const char *pFilename, const CImageInfo &Image);

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1375,6 +1375,38 @@ void CMenus::OnInit()
 	m_DirectionQuadContainerIndex = Graphics()->CreateQuadContainer(false);
 	Graphics()->QuadContainerAddSprite(m_DirectionQuadContainerIndex, 0.f, 0.f, 22.f);
 	Graphics()->QuadContainerUpload(m_DirectionQuadContainerIndex);
+
+	// Prewarm settings pages caches
+	PrewarmSettingsPages();
+}
+
+void CMenus::PrewarmSettingsPages()
+{
+	extern std::unordered_map<std::string, CBindSlot> g_CommandBindCache;
+	extern bool g_CommandBindCacheInitialized;
+
+	if(g_CommandBindCacheInitialized)
+		return;
+
+	g_CommandBindCache.clear();
+	g_CommandBindCache.reserve(64);
+	for(int Mod = 0; Mod < KeyModifier::COMBINATION_COUNT; ++Mod)
+	{
+		for(int KeyId = 0; KeyId < KEY_LAST; ++KeyId)
+		{
+			const char *pBind = GameClient()->m_Binds.Get(KeyId, Mod);
+			if(!pBind[0])
+				continue;
+			g_CommandBindCache.try_emplace(pBind, KeyId, Mod);
+		}
+	}
+	g_CommandBindCacheInitialized = true;
+
+	// Preload skin list to avoid lag when first entering settings
+	GameClient()->m_Skins.SkinList();
+
+	// Preload TClient and QiMeng pages static variables
+	PrewarmTClientAndQiMengPages();
 }
 
 void CMenus::ConchainBackgroundEntities(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData)

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -83,11 +83,14 @@ private:
 
 	// menus_settings_assets.cpp
 public:
+	class CAssetDecodeJob;
+
 	struct SCustomItem
 	{
 		IGraphics::CTextureHandle m_RenderTexture;
 
 		char m_aName[50];
+		std::shared_ptr<CAssetDecodeJob> m_pDecodeJob;
 
 		bool operator<(const SCustomItem &Other) const { return str_comp(m_aName, Other.m_aName) < 0; }
 	};
@@ -665,6 +668,7 @@ protected:
 	void RenderSettingsGraphics(CUIRect MainView);
 	void RenderSettingsSound(CUIRect MainView);
 	void RenderSettings(CUIRect MainView);
+	void PrewarmSettingsPages();
 	void RenderSettingsCustom(CUIRect MainView);
 
 	// found in menus_settings_controls.cpp
@@ -948,6 +952,7 @@ private:
 	void RenderSettingsTClientConfigs(CUIRect MainView);
 	void RenderSettingsTClientSidebar(CUIRect MainView);
 	void RenderSettingsQiMeng(CUIRect MainView);
+	void PrewarmTClientAndQiMengPages();
 	void RenderTeeCute(const CAnimState *pAnim, const CTeeRenderInfo *pInfo, int Emote, vec2 Dir, vec2 Pos, bool CuteEyes, float Alpha = 1.0f);
 
 	const CWarType *m_pRemoveWarType = nullptr;

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -414,28 +414,38 @@ void CMenus::RenderSettingsPlayer(CUIRect MainView)
 
 void CMenus::RenderSettingsTee(CUIRect MainView)
 {
-	CUIRect TabBar, PlayerTab, DummyTab, ChangeInfo;
+	static int s_TeeSubTab = 0; // 0=Player, 1=Dummy, 2=Profiles
+	CUIRect TabBar, PlayerTab, DummyTab, ProfilesTab, ChangeInfo;
 	static bool s_TeeTabTransitionInitialized = false;
 	static bool s_PrevTeeDummy = false;
 	static float s_TeeTabTransitionDirection = 0.0f;
 	const uint64_t TeeTabSwitchNode = UiAnimNodeKey("settings_tee_tab_switch");
 	MainView.HSplitTop(20.0f, &TabBar, &MainView);
 	TabBar.VSplitMid(&TabBar, &ChangeInfo, 20.f);
-	TabBar.VSplitMid(&PlayerTab, &DummyTab);
+	TabBar.VSplitLeft(TabBar.w / 3.0f, &PlayerTab, &TabBar);
+	TabBar.VSplitLeft(TabBar.w / 3.0f, &DummyTab, &ProfilesTab);
 	MainView.HSplitTop(10.0f, nullptr, &MainView);
 
 	static CButtonContainer s_PlayerTabButton;
-	if(DoButton_MenuTab(&s_PlayerTabButton, Localize("Player"), !m_Dummy, &PlayerTab, IGraphics::CORNER_L, nullptr, nullptr, nullptr, nullptr, 4.0f))
+	if(DoButton_MenuTab(&s_PlayerTabButton, Localize("Player"), s_TeeSubTab == 0, &PlayerTab, IGraphics::CORNER_L, nullptr, nullptr, nullptr, nullptr, 4.0f))
 	{
+		s_TeeSubTab = 0;
 		m_Dummy = false;
 		m_SkinListScrollToSelected = true;
 	}
 
 	static CButtonContainer s_DummyTabButton;
-	if(DoButton_MenuTab(&s_DummyTabButton, Localize("Dummy"), m_Dummy, &DummyTab, IGraphics::CORNER_R, nullptr, nullptr, nullptr, nullptr, 4.0f))
+	if(DoButton_MenuTab(&s_DummyTabButton, Localize("Dummy"), s_TeeSubTab == 1, &DummyTab, IGraphics::CORNER_NONE, nullptr, nullptr, nullptr, nullptr, 4.0f))
 	{
+		s_TeeSubTab = 1;
 		m_Dummy = true;
 		m_SkinListScrollToSelected = true;
+	}
+
+	static CButtonContainer s_ProfilesTabButton;
+	if(DoButton_MenuTab(&s_ProfilesTabButton, Localize("Profiles"), s_TeeSubTab == 2, &ProfilesTab, IGraphics::CORNER_R, nullptr, nullptr, nullptr, nullptr, 4.0f))
+	{
+		s_TeeSubTab = 2;
 	}
 
 	if(!s_TeeTabTransitionInitialized)
@@ -455,7 +465,7 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 	float TransitionOffset = 0.0f;
 	bool TransitionActive = TransitionStrength > 0.0f && s_TeeTabTransitionDirection != 0.0f;
 
-	if(Client()->State() == IClient::STATE_ONLINE &&
+	if(s_TeeSubTab != 2 && Client()->State() == IClient::STATE_ONLINE &&
 		GameClient()->m_aNextChangeInfo[m_Dummy] > Client()->GameTick(m_Dummy))
 	{
 		char aChangeInfo[128], aTimeLeft[32];
@@ -471,6 +481,13 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 		str_format(aStats, sizeof(aStats), "unloaded: %" PRIzu ", pending: %" PRIzu ", loading: %" PRIzu ",\nloaded: %" PRIzu ", error: %" PRIzu ", notfound: %" PRIzu,
 			Stats.m_NumUnloaded, Stats.m_NumPending, Stats.m_NumLoading, Stats.m_NumLoaded, Stats.m_NumError, Stats.m_NumNotFound);
 		Ui()->DoLabel(&ChangeInfo, aStats, 9.0f, TEXTALIGN_MR);
+	}
+
+	// Profiles 子标签页
+	if(s_TeeSubTab == 2)
+	{
+		RenderSettingsTClientProfiles(MainView);
+		return;
 	}
 
 	char *pSkinName;
@@ -2087,29 +2104,36 @@ void CMenus::RenderSettings(CUIRect MainView)
 	TabBar.HSplitTop(50.0f, &Button, &TabBar);
 	Button.Draw(ms_ColorTabbarActive, IGraphics::CORNER_BR, 10.0f);
 
-	const char *apTabs[SETTINGS_LENGTH] = {
-		Localize("Language"),
-		Localize("General"),
-		Localize("Player"),
-		Client()->IsSixup() ? "Tee 0.7" : Localize("Tee"),
-		Localize("Appearance"),
-		Localize("Controls"),
-		Localize("Graphics"),
-		Localize("Sound"),
-		Localize("DDNet"),
-		Localize("Assets"),
-		TCLocalize("TClient"),
-		TCLocalize("栖梦"),
-		Localize("Profiles"),
-		Localize("Configs")};
+	static const char *s_apTabs[SETTINGS_LENGTH] = {};
+	static char s_aTabsLanguageFile[IO_MAX_PATH_LENGTH] = {};
+	if(str_comp(s_aTabsLanguageFile, g_Config.m_ClLanguagefile) != 0)
+	{
+		str_copy(s_aTabsLanguageFile, g_Config.m_ClLanguagefile, sizeof(s_aTabsLanguageFile));
+		s_apTabs[SETTINGS_LANGUAGE] = Localize("Language");
+		s_apTabs[SETTINGS_GENERAL] = Localize("General");
+		s_apTabs[SETTINGS_PLAYER] = Localize("Player");
+		s_apTabs[SETTINGS_TEE] = Client()->IsSixup() ? "Tee 0.7" : Localize("Tee");
+		s_apTabs[SETTINGS_APPEARANCE] = Localize("Appearance");
+		s_apTabs[SETTINGS_CONTROLS] = Localize("Controls");
+		s_apTabs[SETTINGS_GRAPHICS] = Localize("Graphics");
+		s_apTabs[SETTINGS_SOUND] = Localize("Sound");
+		s_apTabs[SETTINGS_DDNET] = Localize("DDNet");
+		s_apTabs[SETTINGS_ASSETS] = Localize("Assets");
+		s_apTabs[SETTINGS_TCLIENT] = TCLocalize("TClient");
+		s_apTabs[SETTINGS_QIMENG] = TCLocalize("栖梦");
+		s_apTabs[SETTINGS_PROFILES] = Localize("Profiles");
+		s_apTabs[SETTINGS_CONFIGS] = Localize("Configs");
+	}
 
 	static CButtonContainer s_aTabButtons[SETTINGS_LENGTH];
 
 	for(int i = 0; i < SETTINGS_LENGTH; i++)
 	{
+		if(i == SETTINGS_PROFILES)
+			continue; // Profiles 已合并到 Tee 页面
 		TabBar.HSplitTop(10.0f, nullptr, &TabBar);
 		TabBar.HSplitTop(26.0f, &Button, &TabBar);
-		if(DoButton_MenuTab(&s_aTabButtons[i], apTabs[i], g_Config.m_UiSettingsPage == i, &Button, IGraphics::CORNER_R, &m_aAnimatorsSettingsTab[i]))
+		if(DoButton_MenuTab(&s_aTabButtons[i], s_apTabs[i], g_Config.m_UiSettingsPage == i, &Button, IGraphics::CORNER_R, &m_aAnimatorsSettingsTab[i]))
 			g_Config.m_UiSettingsPage = i;
 	}
 
@@ -2518,19 +2542,24 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 	MainView.HSplitTop(20.0f, &TabBar, &MainView);
 	const float TabWidth = TabBar.w / NUMBER_OF_APPEARANCE_TABS;
 	static CButtonContainer s_aPageTabs[NUMBER_OF_APPEARANCE_TABS] = {};
-	const char *apTabNames[NUMBER_OF_APPEARANCE_TABS] = {
-		Localize("HUD"),
-		Localize("Chat"),
-		Localize("Name Plate"),
-		Localize("Hook Collisions"),
-		Localize("Info Messages"),
-		Localize("Laser")};
+	static const char *s_apAppearanceTabNames[NUMBER_OF_APPEARANCE_TABS] = {};
+	static char s_aAppearanceLanguageFile[IO_MAX_PATH_LENGTH] = {};
+	if(str_comp(s_aAppearanceLanguageFile, g_Config.m_ClLanguagefile) != 0)
+	{
+		str_copy(s_aAppearanceLanguageFile, g_Config.m_ClLanguagefile, sizeof(s_aAppearanceLanguageFile));
+		s_apAppearanceTabNames[APPEARANCE_TAB_HUD] = Localize("HUD");
+		s_apAppearanceTabNames[APPEARANCE_TAB_CHAT] = Localize("Chat");
+		s_apAppearanceTabNames[APPEARANCE_TAB_NAME_PLATE] = Localize("Name Plate");
+		s_apAppearanceTabNames[APPEARANCE_TAB_HOOK_COLLISION] = Localize("Hook Collisions");
+		s_apAppearanceTabNames[APPEARANCE_TAB_INFO_MESSAGES] = Localize("Info Messages");
+		s_apAppearanceTabNames[APPEARANCE_TAB_LASER] = Localize("Laser");
+	}
 
 	for(int Tab = APPEARANCE_TAB_HUD; Tab < NUMBER_OF_APPEARANCE_TABS; ++Tab)
 	{
 		TabBar.VSplitLeft(TabWidth, &Button, &TabBar);
 		const int Corners = Tab == APPEARANCE_TAB_HUD ? IGraphics::CORNER_L : (Tab == NUMBER_OF_APPEARANCE_TABS - 1 ? IGraphics::CORNER_R : IGraphics::CORNER_NONE);
-		if(DoButton_MenuTab(&s_aPageTabs[Tab], apTabNames[Tab], s_CurTab == Tab, &Button, Corners, nullptr, nullptr, nullptr, nullptr, 4.0f))
+		if(DoButton_MenuTab(&s_aPageTabs[Tab], s_apAppearanceTabNames[Tab], s_CurTab == Tab, &Button, Corners, nullptr, nullptr, nullptr, nullptr, 4.0f))
 		{
 			s_CurTab = Tab;
 		}

--- a/src/game/client/components/menus_settings_assets.cpp
+++ b/src/game/client/components/menus_settings_assets.cpp
@@ -69,7 +69,7 @@ private:
 
 		if(IsWebp)
 		{
-			Success = CImageLoader::LoadWebp(m_vFileData.data(), m_vFileData.size(), m_Name.c_str(), Image);
+			Success = CImageLoader::LoadWebP(m_vFileData.data(), m_vFileData.size(), m_Name.c_str(), Image);
 		}
 		else if(IsPng)
 		{
@@ -77,7 +77,7 @@ private:
 		}
 		else
 		{
-			if(CImageLoader::LoadWebp(m_vFileData.data(), m_vFileData.size(), m_Name.c_str(), Image))
+			if(CImageLoader::LoadWebP(m_vFileData.data(), m_vFileData.size(), m_Name.c_str(), Image))
 				Success = true;
 			else if(CImageLoader::LoadPng(m_vFileData.data(), m_vFileData.size(), m_Name.c_str(), Image))
 				Success = true;
@@ -156,7 +156,7 @@ private:
 
 		if(IsWebp)
 		{
-			Success = CImageLoader::LoadWebp(m_vFileData.data(), m_vFileData.size(), m_Name.c_str(), Image);
+			Success = CImageLoader::LoadWebP(m_vFileData.data(), m_vFileData.size(), m_Name.c_str(), Image);
 		}
 		else if(IsPng)
 		{
@@ -164,7 +164,7 @@ private:
 		}
 		else
 		{
-			if(CImageLoader::LoadWebp(m_vFileData.data(), m_vFileData.size(), m_Name.c_str(), Image))
+			if(CImageLoader::LoadWebP(m_vFileData.data(), m_vFileData.size(), m_Name.c_str(), Image))
 				Success = true;
 			else if(CImageLoader::LoadPng(m_vFileData.data(), m_vFileData.size(), m_Name.c_str(), Image))
 				Success = true;

--- a/src/game/client/components/menus_settings_assets.cpp
+++ b/src/game/client/components/menus_settings_assets.cpp
@@ -4,8 +4,12 @@
 
 #include <base/system.h>
 
+#include <engine/engine.h>
+#include <engine/gfx/image_loader.h>
+#include <engine/gfx/image_manipulation.h>
 #include <engine/shared/config.h>
 #include <engine/shared/http.h>
+#include <engine/shared/jobs.h>
 #include <engine/shared/json.h>
 #include <engine/storage.h>
 #include <engine/textrender.h>
@@ -13,20 +17,239 @@
 #include <game/client/gameclient.h>
 #include <game/client/ui_listbox.h>
 #include <game/localization.h>
+#include <game/mapitems.h>
 
 #include <chrono>
+#include <mutex>
 #include <string>
+#include <unordered_set>
 
 using namespace FontIcons;
 using namespace std::chrono_literals;
 
 typedef std::function<void()> TMenuAssetScanLoadedFunc;
 
+class CMenus::CAssetDecodeJob : public IJob
+{
+public:
+	struct SResult
+	{
+		CImageInfo m_Image;
+		bool m_Success = false;
+	};
+
+private:
+	std::vector<uint8_t> m_vFileData;
+	std::string m_Name;
+	std::mutex m_Mutex;
+	SResult m_Result;
+	bool m_Completed = false;
+
+	void Run() override
+	{
+		if(m_vFileData.empty())
+		{
+			std::lock_guard<std::mutex> Lock(m_Mutex);
+			m_Completed = true;
+			return;
+		}
+
+		CImageInfo Image;
+		bool Success = false;
+
+		constexpr uint8_t PNG_SIGNATURE[] = {0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A};
+		constexpr uint8_t WEBP_RIFF[] = {0x52, 0x49, 0x46, 0x46};
+		constexpr uint8_t WEBP_WEBP[] = {0x57, 0x45, 0x42, 0x50};
+
+		const bool IsPng = m_vFileData.size() >= 8 &&
+			memcmp(m_vFileData.data(), PNG_SIGNATURE, 8) == 0;
+		const bool IsWebp = m_vFileData.size() >= 12 &&
+			memcmp(m_vFileData.data(), WEBP_RIFF, 4) == 0 &&
+			memcmp(m_vFileData.data() + 8, WEBP_WEBP, 4) == 0;
+
+		if(IsWebp)
+		{
+			Success = CImageLoader::LoadWebp(m_vFileData.data(), m_vFileData.size(), m_Name.c_str(), Image);
+		}
+		else if(IsPng)
+		{
+			Success = CImageLoader::LoadPng(m_vFileData.data(), m_vFileData.size(), m_Name.c_str(), Image);
+		}
+		else
+		{
+			if(CImageLoader::LoadWebp(m_vFileData.data(), m_vFileData.size(), m_Name.c_str(), Image))
+				Success = true;
+			else if(CImageLoader::LoadPng(m_vFileData.data(), m_vFileData.size(), m_Name.c_str(), Image))
+				Success = true;
+		}
+
+		{
+			std::lock_guard<std::mutex> Lock(m_Mutex);
+			m_Result.m_Image = std::move(Image);
+			m_Result.m_Success = Success;
+			m_Completed = true;
+		}
+
+		m_vFileData.clear();
+		m_vFileData.shrink_to_fit();
+	}
+
+public:
+	CAssetDecodeJob(std::vector<uint8_t> &&vFileData, const char *pName) :
+		m_vFileData(std::move(vFileData)),
+		m_Name(pName)
+	{
+	}
+
+	bool IsCompleted() const
+	{
+		std::lock_guard<std::mutex> Lock(const_cast<std::mutex &>(m_Mutex));
+		return m_Completed;
+	}
+
+	SResult GetResult()
+	{
+		std::lock_guard<std::mutex> Lock(m_Mutex);
+		SResult Result = std::move(m_Result);
+		m_Result = SResult();
+		return Result;
+	}
+};
+
+class CImageDecodeJob : public IJob
+{
+public:
+	struct SResult
+	{
+		CImageInfo m_Image;
+		bool m_Success = false;
+	};
+
+private:
+	std::vector<uint8_t> m_vFileData;
+	std::string m_Name;
+	std::mutex m_Mutex;
+	SResult m_Result;
+	bool m_Completed = false;
+
+	void Run() override
+	{
+		if(m_vFileData.empty())
+		{
+			std::lock_guard<std::mutex> Lock(m_Mutex);
+			m_Completed = true;
+			return;
+		}
+
+		CImageInfo Image;
+		bool Success = false;
+
+		constexpr uint8_t PNG_SIGNATURE[] = {0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A};
+		constexpr uint8_t WEBP_RIFF[] = {0x52, 0x49, 0x46, 0x46};
+		constexpr uint8_t WEBP_WEBP[] = {0x57, 0x45, 0x42, 0x50};
+
+		const bool IsPng = m_vFileData.size() >= 8 && 
+			memcmp(m_vFileData.data(), PNG_SIGNATURE, 8) == 0;
+		const bool IsWebp = m_vFileData.size() >= 12 && 
+			memcmp(m_vFileData.data(), WEBP_RIFF, 4) == 0 &&
+			memcmp(m_vFileData.data() + 8, WEBP_WEBP, 4) == 0;
+
+		if(IsWebp)
+		{
+			Success = CImageLoader::LoadWebp(m_vFileData.data(), m_vFileData.size(), m_Name.c_str(), Image);
+		}
+		else if(IsPng)
+		{
+			Success = CImageLoader::LoadPng(m_vFileData.data(), m_vFileData.size(), m_Name.c_str(), Image);
+		}
+		else
+		{
+			if(CImageLoader::LoadWebp(m_vFileData.data(), m_vFileData.size(), m_Name.c_str(), Image))
+				Success = true;
+			else if(CImageLoader::LoadPng(m_vFileData.data(), m_vFileData.size(), m_Name.c_str(), Image))
+				Success = true;
+		}
+
+		{
+			std::lock_guard<std::mutex> Lock(m_Mutex);
+			m_Result.m_Image = std::move(Image);
+			m_Result.m_Success = Success;
+			m_Completed = true;
+		}
+
+		m_vFileData.clear();
+		m_vFileData.shrink_to_fit();
+	}
+
+public:
+	CImageDecodeJob(std::vector<uint8_t> &&vFileData, const char *pName) :
+		m_vFileData(std::move(vFileData)),
+		m_Name(pName)
+	{
+	}
+
+	bool IsCompleted() const
+	{
+		std::lock_guard<std::mutex> Lock(const_cast<std::mutex &>(m_Mutex));
+		return m_Completed;
+	}
+
+	SResult GetResult()
+	{
+		std::lock_guard<std::mutex> Lock(m_Mutex);
+		SResult Result = std::move(m_Result);
+		m_Result = SResult();
+		return Result;
+	}
+};
+
+static std::string JsonEscape(const std::string &Str)
+{
+	std::string Result;
+	Result.reserve(Str.size());
+	for(char c : Str)
+	{
+		switch(c)
+		{
+		case '"': Result += "\\\""; break;
+		case '\\': Result += "\\\\"; break;
+		case '\n': Result += "\\n"; break;
+		case '\r': Result += "\\r"; break;
+		case '\t': Result += "\\t"; break;
+		default: Result += c; break;
+		}
+	}
+	return Result;
+}
+
 struct SMenuAssetScanUser
 {
 	void *m_pUser;
 	TMenuAssetScanLoadedFunc m_LoadedFunc;
 };
+
+static bool LoadFileToBuffer(IStorage *pStorage, const char *pFilename, int StorageType, std::vector<uint8_t> &vBuffer)
+{
+	IOHANDLE File = pStorage->OpenFile(pFilename, IOFLAG_READ, StorageType);
+	if(!File)
+		return false;
+
+	io_seek(File, 0, IOSEEK_END);
+	const int64_t Size = io_tell(File);
+	io_seek(File, 0, IOSEEK_START);
+
+	if(Size <= 0 || Size > 10 * 1024 * 1024)
+	{
+		io_close(File);
+		return false;
+	}
+
+	vBuffer.resize(Size);
+	const size_t Read = io_read(File, vBuffer.data(), Size);
+	io_close(File);
+
+	return Read == (size_t)Size;
+}
 
 // IDs of the tabs in the Assets menu
 enum
@@ -46,17 +269,47 @@ void CMenus::LoadEntities(SCustomEntities *pEntitiesItem, void *pUser)
 	auto *pThis = (CMenus *)pRealUser->m_pUser;
 
 	char aPath[IO_MAX_PATH_LENGTH];
-
-	// Only one preview texture is needed for the assets list. Loading all
-	// entities variants here causes unnecessary synchronous disk/PNG work.
-	IGraphics::CTextureHandle Texture;
 	if(str_comp(pEntitiesItem->m_aName, "default") == 0)
 	{
 		for(int i = 0; i < MAP_IMAGE_MOD_TYPE_COUNT; ++i)
 		{
 			str_format(aPath, sizeof(aPath), "editor/entities_clear/%s.png", gs_apModEntitiesNames[i]);
-			Texture = pThis->Graphics()->LoadTexture(aPath, IStorage::TYPE_ALL);
-			if(!Texture.IsNullTexture())
+			pEntitiesItem->m_aImages[i].m_Texture = pThis->Graphics()->LoadTexture(aPath, IStorage::TYPE_ALL);
+			if(!pEntitiesItem->m_RenderTexture.IsValid() || pEntitiesItem->m_RenderTexture.IsNullTexture())
+				pEntitiesItem->m_RenderTexture = pEntitiesItem->m_aImages[i].m_Texture;
+		}
+	}
+	else
+	{
+		for(int i = 0; i < MAP_IMAGE_MOD_TYPE_COUNT; ++i)
+		{
+			str_format(aPath, sizeof(aPath), "assets/entities/%s/%s.png", pEntitiesItem->m_aName, gs_apModEntitiesNames[i]);
+			pEntitiesItem->m_aImages[i].m_Texture = pThis->Graphics()->LoadTexture(aPath, IStorage::TYPE_ALL);
+			if(pEntitiesItem->m_aImages[i].m_Texture.IsNullTexture())
+			{
+				str_format(aPath, sizeof(aPath), "assets/entities/%s.png", pEntitiesItem->m_aName);
+				pEntitiesItem->m_aImages[i].m_Texture = pThis->Graphics()->LoadTexture(aPath, IStorage::TYPE_ALL);
+			}
+			if(!pEntitiesItem->m_RenderTexture.IsValid() || pEntitiesItem->m_RenderTexture.IsNullTexture())
+				pEntitiesItem->m_RenderTexture = pEntitiesItem->m_aImages[i].m_Texture;
+		}
+	}
+}
+
+static void StartEntitiesDecode(CMenus::SCustomEntities *pEntitiesItem, IStorage *pStorage, IEngine *pEngine)
+{
+	if(pEntitiesItem->m_pDecodeJob || pEntitiesItem->m_RenderTexture.IsValid())
+		return;
+
+	std::vector<uint8_t> vFileData;
+	char aPath[IO_MAX_PATH_LENGTH];
+
+	if(str_comp(pEntitiesItem->m_aName, "default") == 0)
+	{
+		for(int i = 0; i < MAP_IMAGE_MOD_TYPE_COUNT; ++i)
+		{
+			str_format(aPath, sizeof(aPath), "editor/entities_clear/%s.png", gs_apModEntitiesNames[i]);
+			if(LoadFileToBuffer(pStorage, aPath, IStorage::TYPE_ALL, vFileData))
 				break;
 		}
 	}
@@ -65,19 +318,21 @@ void CMenus::LoadEntities(SCustomEntities *pEntitiesItem, void *pUser)
 		for(int i = 0; i < MAP_IMAGE_MOD_TYPE_COUNT; ++i)
 		{
 			str_format(aPath, sizeof(aPath), "assets/entities/%s/%s.png", pEntitiesItem->m_aName, gs_apModEntitiesNames[i]);
-			Texture = pThis->Graphics()->LoadTexture(aPath, IStorage::TYPE_ALL);
-			if(!Texture.IsNullTexture())
+			if(LoadFileToBuffer(pStorage, aPath, IStorage::TYPE_ALL, vFileData))
 				break;
 		}
-		if(Texture.IsNullTexture())
+		if(vFileData.empty())
 		{
 			str_format(aPath, sizeof(aPath), "assets/entities/%s.png", pEntitiesItem->m_aName);
-			Texture = pThis->Graphics()->LoadTexture(aPath, IStorage::TYPE_ALL);
+			LoadFileToBuffer(pStorage, aPath, IStorage::TYPE_ALL, vFileData);
 		}
 	}
 
-	pEntitiesItem->m_aImages[0].m_Texture = Texture;
-	pEntitiesItem->m_RenderTexture = Texture;
+	if(!vFileData.empty())
+	{
+		pEntitiesItem->m_pDecodeJob = std::make_shared<CMenus::CAssetDecodeJob>(std::move(vFileData), pEntitiesItem->m_aName);
+		pEngine->AddJob(pEntitiesItem->m_pDecodeJob);
+	}
 }
 
 int CMenus::EntitiesScan(const char *pName, int IsDir, int DirType, void *pUser)
@@ -116,6 +371,38 @@ int CMenus::EntitiesScan(const char *pName, int IsDir, int DirType, void *pUser)
 	pRealUser->m_LoadedFunc();
 
 	return 0;
+}
+
+template<typename TName>
+static void StartAssetDecode(TName *pAssetItem, const char *pAssetName, IStorage *pStorage, IEngine *pEngine)
+{
+	if(pAssetItem->m_pDecodeJob || pAssetItem->m_RenderTexture.IsValid())
+		return;
+
+	std::vector<uint8_t> vFileData;
+	char aPath[IO_MAX_PATH_LENGTH];
+
+	if(str_comp(pAssetItem->m_aName, "default") == 0)
+	{
+		str_format(aPath, sizeof(aPath), "%s.png", pAssetName);
+		LoadFileToBuffer(pStorage, aPath, IStorage::TYPE_ALL, vFileData);
+	}
+	else
+	{
+		str_format(aPath, sizeof(aPath), "assets/%s/%s.png", pAssetName, pAssetItem->m_aName);
+		LoadFileToBuffer(pStorage, aPath, IStorage::TYPE_ALL, vFileData);
+		if(vFileData.empty())
+		{
+			str_format(aPath, sizeof(aPath), "assets/%s/%s/%s.png", pAssetName, pAssetItem->m_aName, pAssetName);
+			LoadFileToBuffer(pStorage, aPath, IStorage::TYPE_ALL, vFileData);
+		}
+	}
+
+	if(!vFileData.empty())
+	{
+		pAssetItem->m_pDecodeJob = std::make_shared<CMenus::CAssetDecodeJob>(std::move(vFileData), pAssetItem->m_aName);
+		pEngine->AddJob(pAssetItem->m_pDecodeJob);
+	}
 }
 
 template<typename TName>
@@ -268,6 +555,8 @@ struct SWorkshopHudAsset
 	std::shared_ptr<CHttpRequest> m_pDownloadTask;
 	bool m_DownloadFailed = false;
 	bool m_Installed = false;
+	
+	std::shared_ptr<CImageDecodeJob> m_pDecodeJob;
 };
 
 struct SWorkshopHudState
@@ -277,6 +566,8 @@ struct SWorkshopHudState
 	bool m_Requested = false;
 	bool m_LoadFailed = false;
 	char m_aError[128] = "";
+	double m_CacheTime = 0.0;
+	double m_LastRefreshTime = 0.0;
 };
 
 struct SDeleteDirectoryEntry
@@ -295,6 +586,35 @@ static SWorkshopHudState gs_WorkshopEntitiesState;
 static SWorkshopHudState gs_WorkshopGameState;
 static SWorkshopHudState gs_WorkshopEmoticonsState;
 static SWorkshopHudState gs_WorkshopParticlesState;
+
+} // namespace
+
+namespace
+{
+
+static void StartBackgroundDecode(SWorkshopHudAsset &Asset, IStorage *pStorage, IEngine *pEngine)
+{
+	if(Asset.m_pDecodeJob || Asset.m_ThumbTexture.IsValid())
+		return;
+
+	std::vector<uint8_t> vFileData;
+
+	if(Asset.m_Installed && !Asset.m_InstallPath.empty())
+	{
+		LoadFileToBuffer(pStorage, Asset.m_InstallPath.c_str(), IStorage::TYPE_SAVE, vFileData);
+	}
+
+	if(vFileData.empty() && !Asset.m_ThumbCachePath.empty())
+	{
+		LoadFileToBuffer(pStorage, Asset.m_ThumbCachePath.c_str(), IStorage::TYPE_SAVE, vFileData);
+	}
+
+	if(!vFileData.empty())
+	{
+		Asset.m_pDecodeJob = std::make_shared<CImageDecodeJob>(std::move(vFileData), Asset.m_Name.c_str());
+		pEngine->AddJob(Asset.m_pDecodeJob);
+	}
+}
 
 int CollectDeleteDirectoryEntries(const char *pName, int IsDir, int DirType, void *pUser)
 {
@@ -530,7 +850,8 @@ bool ParseWorkshopAssets(const json_value *pRoot, const char *pCategoryFilter, c
 		if(aSafeId[0] == '\0')
 			str_copy(aSafeId, "asset", sizeof(aSafeId));
 		char aThumbPath[IO_MAX_PATH_LENGTH];
-		str_format(aThumbPath, sizeof(aThumbPath), "qmclient/workshop/thumbs/%s.%s", aSafeId, aExt);
+		// Always use webp for thumbnail cache to save space
+		str_format(aThumbPath, sizeof(aThumbPath), "qmclient/workshop/thumbs/%s.webp", aSafeId);
 		Asset.m_ThumbCachePath = aThumbPath;
 
 		vOut.push_back(std::move(Asset));
@@ -563,7 +884,117 @@ void ResetWorkshopState(SWorkshopHudState &WorkshopState, IGraphics *pGraphics, 
 	WorkshopState.m_vAssets.clear();
 	WorkshopState.m_Requested = false;
 	WorkshopState.m_LoadFailed = false;
+	// Keep m_CacheTime and m_LastRefreshTime for cache reuse
 	str_copy(WorkshopState.m_aError, "");
+}
+
+// Serialize Workshop assets to JSON file for local cache
+static bool SaveWorkshopCache(SWorkshopHudState &WorkshopState, IStorage *pStorage, const char *pCachePath)
+{
+	if(WorkshopState.m_vAssets.empty())
+		return false;
+
+	char aFullPath[IO_MAX_PATH_LENGTH];
+	str_format(aFullPath, sizeof(aFullPath), "cache/%s", pCachePath);
+
+	IOHANDLE File = pStorage->OpenFile(aFullPath, IOFLAG_WRITE, IStorage::TYPE_SAVE);
+	if(!File)
+		return false;
+
+	std::string JsonStr = "[";
+	for(size_t i = 0; i < WorkshopState.m_vAssets.size(); ++i)
+	{
+		const SWorkshopHudAsset &Asset = WorkshopState.m_vAssets[i];
+		if(i > 0) JsonStr += ",";
+		JsonStr += "{";
+		JsonStr += "\"id\":\"" + JsonEscape(Asset.m_Id) + "\",";
+		JsonStr += "\"name\":\"" + JsonEscape(Asset.m_Name) + "\",";
+		JsonStr += "\"author\":\"" + JsonEscape(Asset.m_Author) + "\",";
+		JsonStr += "\"image_url\":\"" + JsonEscape(Asset.m_ImageUrl) + "\",";
+		JsonStr += "\"thumb_cache\":\"" + JsonEscape(Asset.m_ThumbCachePath) + "\",";
+		JsonStr += "\"install_path\":\"" + JsonEscape(Asset.m_InstallPath) + "\"";
+		JsonStr += "}";
+	}
+	JsonStr += "]";
+
+	io_write(File, JsonStr.c_str(), JsonStr.size());
+	io_close(File);
+	return true;
+}
+
+// Load Workshop assets from local cache
+static bool LoadWorkshopCache(SWorkshopHudState &WorkshopState, IStorage *pStorage, const char *pCachePath)
+{
+	char aFullPath[IO_MAX_PATH_LENGTH];
+	str_format(aFullPath, sizeof(aFullPath), "cache/%s", pCachePath);
+
+	IOHANDLE File = pStorage->OpenFile(aFullPath, IOFLAG_READ, IStorage::TYPE_SAVE);
+	if(!File)
+		return false;
+
+	char aBuffer[1024 * 512]; // 512KB buffer
+	long FileSize = io_length(File);
+	if(FileSize <= 0 || FileSize >= (long)sizeof(aBuffer))
+	{
+		io_close(File);
+		return false;
+	}
+
+	io_read(File, aBuffer, FileSize);
+	aBuffer[FileSize] = '\0';
+	io_close(File);
+
+	json_settings JsonSettings = {};
+	char JsonError[1024];
+	json_value *pJson = json_parse_ex(&JsonSettings, aBuffer, FileSize, JsonError);
+	if(!pJson)
+		return false;
+
+	WorkshopState.m_vAssets.clear();
+	for(unsigned i = 0; i < pJson->u.array.length; ++i)
+	{
+		json_value *pItem = pJson->u.array.values[i];
+		if(pItem->type != json_object)
+			continue;
+
+		SWorkshopHudAsset Asset;
+		for(unsigned j = 0; j < pItem->u.object.length; ++j)
+		{
+			const char *pKey = pItem->u.object.values[j].name;
+			json_value *pVal = pItem->u.object.values[j].value;
+			if(str_comp(pKey, "id") == 0 && pVal->type == json_string)
+				Asset.m_Id = pVal->u.string.ptr;
+			else if(str_comp(pKey, "name") == 0 && pVal->type == json_string)
+				Asset.m_Name = pVal->u.string.ptr;
+			else if(str_comp(pKey, "author") == 0 && pVal->type == json_string)
+				Asset.m_Author = pVal->u.string.ptr;
+			else if(str_comp(pKey, "image_url") == 0 && pVal->type == json_string)
+				Asset.m_ImageUrl = pVal->u.string.ptr;
+			else if(str_comp(pKey, "thumb_cache") == 0 && pVal->type == json_string)
+				Asset.m_ThumbCachePath = pVal->u.string.ptr;
+			else if(str_comp(pKey, "install_path") == 0 && pVal->type == json_string)
+				Asset.m_InstallPath = pVal->u.string.ptr;
+		}
+		Asset.m_Installed = pStorage->FileExists(Asset.m_InstallPath.c_str(), IStorage::TYPE_SAVE);
+		WorkshopState.m_vAssets.push_back(std::move(Asset));
+	}
+
+	json_value_free(pJson);
+	return !WorkshopState.m_vAssets.empty();
+}
+
+// Get cache filename for a workshop tab
+static const char *GetWorkshopCacheFilename(int Tab)
+{
+	switch(Tab)
+	{
+	case ASSETS_TAB_HUD: return "workshop_hud.json";
+	case ASSETS_TAB_ENTITIES: return "workshop_entities.json";
+	case ASSETS_TAB_GAME: return "workshop_game.json";
+	case ASSETS_TAB_EMOTICONS: return "workshop_emoticons.json";
+	case ASSETS_TAB_PARTICLES: return "workshop_particles.json";
+	default: return nullptr;
+	}
 }
 
 bool DeleteLocalAssetByTab(IStorage *pStorage, int CurTab, const char *pAssetName)
@@ -626,10 +1057,9 @@ void CMenus::ClearCustomItems(int CurTab)
 	{
 		for(auto &Entity : m_vEntitiesList)
 		{
-			Graphics()->UnloadTexture(&Entity.m_RenderTexture);
 			for(auto &Image : Entity.m_aImages)
 			{
-				Image.m_Texture.Invalidate();
+				Graphics()->UnloadTexture(&Image.m_Texture);
 			}
 		}
 		m_vEntitiesList.clear();
@@ -720,25 +1150,31 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 	static bool s_AssetsTransitionInitialized = false;
 	static int s_PrevAssetsTab = ASSETS_TAB_ENTITIES;
 	static float s_AssetsTransitionDirection = 0.0f;
+	static bool s_EntityGamePreview = true;
 	const uint64_t AssetsTabSwitchNode = UiAnimNodeKey("settings_assets_tab_switch");
 
 	MainView.HSplitTop(20.0f, &TabBar, &MainView);
 	const float TabWidth = TabBar.w / NUMBER_OF_ASSETS_TABS;
 	static CButtonContainer s_aPageTabs[NUMBER_OF_ASSETS_TABS] = {};
-	const char *apTabNames[NUMBER_OF_ASSETS_TABS] = {
-		Localize("Entities"),
-		Localize("Game"),
-		Localize("Emoticons"),
-		Localize("Particles"),
-		Localize("HUD"),
-		Localize("Extras")};
+	static const char *s_apAssetsTabNames[NUMBER_OF_ASSETS_TABS] = {};
+	static char s_aAssetsLanguageFile[IO_MAX_PATH_LENGTH] = {};
+	if(str_comp(s_aAssetsLanguageFile, g_Config.m_ClLanguagefile) != 0)
+	{
+		str_copy(s_aAssetsLanguageFile, g_Config.m_ClLanguagefile, sizeof(s_aAssetsLanguageFile));
+		s_apAssetsTabNames[ASSETS_TAB_ENTITIES] = Localize("Entities");
+		s_apAssetsTabNames[ASSETS_TAB_GAME] = Localize("Game");
+		s_apAssetsTabNames[ASSETS_TAB_EMOTICONS] = Localize("Emoticons");
+		s_apAssetsTabNames[ASSETS_TAB_PARTICLES] = Localize("Particles");
+		s_apAssetsTabNames[ASSETS_TAB_HUD] = Localize("HUD");
+		s_apAssetsTabNames[ASSETS_TAB_EXTRAS] = Localize("Extras");
+	}
 
 	for(int Tab = ASSETS_TAB_ENTITIES; Tab < NUMBER_OF_ASSETS_TABS; ++Tab)
 	{
 		CUIRect Button;
 		TabBar.VSplitLeft(TabWidth, &Button, &TabBar);
 		const int Corners = Tab == ASSETS_TAB_ENTITIES ? IGraphics::CORNER_L : (Tab == NUMBER_OF_ASSETS_TABS - 1 ? IGraphics::CORNER_R : IGraphics::CORNER_NONE);
-		if(DoButton_MenuTab(&s_aPageTabs[Tab], apTabNames[Tab], s_CurCustomTab == Tab, &Button, Corners, nullptr, nullptr, nullptr, nullptr, 4.0f))
+		if(DoButton_MenuTab(&s_aPageTabs[Tab], s_apAssetsTabNames[Tab], s_CurCustomTab == Tab, &Button, Corners, nullptr, nullptr, nullptr, nullptr, 4.0f))
 		{
 			s_CurCustomTab = Tab;
 		}
@@ -869,70 +1305,122 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 	float TextureHeight = 150;
 	SMenuAssetScanUser LazyLoadUser;
 	LazyLoadUser.m_pUser = this;
-	constexpr int MaxPreviewTextureLoadsPerFrame = 1;
-	int PreviewTextureLoadsThisFrame = 0;
-	auto EnsurePreviewTextureLoaded = [&](size_t Index) {
-		if(PreviewTextureLoadsThisFrame >= MaxPreviewTextureLoadsPerFrame)
-			return;
+	constexpr int MaxGpuUploadsPerFrame = 30;
+	int GpuUploadsThisFrame = 0;
 
-		bool Loaded = false;
+	auto UploadCompletedDecodeJob = [&](SCustomItem *pItem) {
+		if(!pItem->m_pDecodeJob || !pItem->m_pDecodeJob->IsCompleted())
+			return;
+		if(GpuUploadsThisFrame >= MaxGpuUploadsPerFrame)
+			return;
+		if(pItem->m_RenderTexture.IsValid())
+		{
+			pItem->m_pDecodeJob.reset();
+			return;
+		}
+		CMenus::CAssetDecodeJob::SResult Result = pItem->m_pDecodeJob->GetResult();
+		pItem->m_pDecodeJob.reset();
+		if(Result.m_Success && Result.m_Image.m_pData)
+		{
+			constexpr int MaxPreviewSize = 512;
+			if(Result.m_Image.m_Width > MaxPreviewSize || Result.m_Image.m_Height > MaxPreviewSize)
+			{
+				int NewWidth = Result.m_Image.m_Width;
+				int NewHeight = Result.m_Image.m_Height;
+				if(NewWidth > NewHeight)
+				{
+					NewHeight = (int)((float)NewHeight * MaxPreviewSize / NewWidth);
+					NewWidth = MaxPreviewSize;
+				}
+				else
+				{
+					NewWidth = (int)((float)NewWidth * MaxPreviewSize / NewHeight);
+					NewHeight = MaxPreviewSize;
+				}
+				ResizeImage(Result.m_Image, NewWidth, NewHeight);
+			}
+			pItem->m_RenderTexture = Graphics()->LoadTextureRaw(Result.m_Image, 0, pItem->m_aName);
+			Result.m_Image.Free();
+			++GpuUploadsThisFrame;
+		}
+	};
+
+	auto StartPreviewDecode = [&](size_t Index) {
 		if(s_CurCustomTab == ASSETS_TAB_ENTITIES)
 		{
 			SCustomEntities *pEntity = gs_vpSearchEntitiesList[Index];
-			if(!pEntity->m_RenderTexture.IsValid())
-			{
-				LoadEntities(pEntity, &LazyLoadUser);
-				Loaded = true;
-			}
+			if(pEntity->m_RenderTexture.IsValid() || pEntity->m_pDecodeJob)
+				return;
+			StartEntitiesDecode(pEntity, Storage(), Engine());
 		}
 		else if(s_CurCustomTab == ASSETS_TAB_GAME)
 		{
 			SCustomGame *pGame = gs_vpSearchGamesList[Index];
-			if(!pGame->m_RenderTexture.IsValid())
-			{
-				LoadAsset(pGame, "game", Graphics());
-				Loaded = true;
-			}
+			if(pGame->m_RenderTexture.IsValid() || pGame->m_pDecodeJob)
+				return;
+			StartAssetDecode(pGame, "game", Storage(), Engine());
 		}
 		else if(s_CurCustomTab == ASSETS_TAB_EMOTICONS)
 		{
 			SCustomEmoticon *pEmoticon = gs_vpSearchEmoticonsList[Index];
-			if(!pEmoticon->m_RenderTexture.IsValid())
-			{
-				LoadAsset(pEmoticon, "emoticons", Graphics());
-				Loaded = true;
-			}
+			if(pEmoticon->m_RenderTexture.IsValid() || pEmoticon->m_pDecodeJob)
+				return;
+			StartAssetDecode(pEmoticon, "emoticons", Storage(), Engine());
 		}
 		else if(s_CurCustomTab == ASSETS_TAB_PARTICLES)
 		{
 			SCustomParticle *pParticle = gs_vpSearchParticlesList[Index];
-			if(!pParticle->m_RenderTexture.IsValid())
-			{
-				LoadAsset(pParticle, "particles", Graphics());
-				Loaded = true;
-			}
+			if(pParticle->m_RenderTexture.IsValid() || pParticle->m_pDecodeJob)
+				return;
+			StartAssetDecode(pParticle, "particles", Storage(), Engine());
 		}
 		else if(s_CurCustomTab == ASSETS_TAB_HUD)
 		{
 			SCustomHud *pHud = gs_vpSearchHudList[Index];
-			if(!pHud->m_RenderTexture.IsValid())
-			{
-				LoadAsset(pHud, "hud", Graphics());
-				Loaded = true;
-			}
+			if(pHud->m_RenderTexture.IsValid() || pHud->m_pDecodeJob)
+				return;
+			StartAssetDecode(pHud, "hud", Storage(), Engine());
 		}
 		else if(s_CurCustomTab == ASSETS_TAB_EXTRAS)
 		{
 			SCustomExtras *pExtras = gs_vpSearchExtrasList[Index];
-			if(!pExtras->m_RenderTexture.IsValid())
-			{
-				LoadAsset(pExtras, "extras", Graphics());
-				Loaded = true;
-			}
+			if(pExtras->m_RenderTexture.IsValid() || pExtras->m_pDecodeJob)
+				return;
+			StartAssetDecode(pExtras, "extras", Storage(), Engine());
 		}
+	};
 
-		if(Loaded)
-			++PreviewTextureLoadsThisFrame;
+	auto ProcessCompletedDecodeJobs = [&]() {
+		if(s_CurCustomTab == ASSETS_TAB_ENTITIES)
+		{
+			for(auto *pEntity : gs_vpSearchEntitiesList)
+				UploadCompletedDecodeJob(pEntity);
+		}
+		else if(s_CurCustomTab == ASSETS_TAB_GAME)
+		{
+			for(auto *pGame : gs_vpSearchGamesList)
+				UploadCompletedDecodeJob(pGame);
+		}
+		else if(s_CurCustomTab == ASSETS_TAB_EMOTICONS)
+		{
+			for(auto *pEmoticon : gs_vpSearchEmoticonsList)
+				UploadCompletedDecodeJob(pEmoticon);
+		}
+		else if(s_CurCustomTab == ASSETS_TAB_PARTICLES)
+		{
+			for(auto *pParticle : gs_vpSearchParticlesList)
+				UploadCompletedDecodeJob(pParticle);
+		}
+		else if(s_CurCustomTab == ASSETS_TAB_HUD)
+		{
+			for(auto *pHud : gs_vpSearchHudList)
+				UploadCompletedDecodeJob(pHud);
+		}
+		else if(s_CurCustomTab == ASSETS_TAB_EXTRAS)
+		{
+			for(auto *pExtras : gs_vpSearchExtrasList)
+				UploadCompletedDecodeJob(pExtras);
+		}
 	};
 
 	size_t SearchListSize = 0;
@@ -963,12 +1451,20 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 		SearchListSize = gs_vpSearchExtrasList.size();
 	}
 
+	for(size_t i = 0; i < SearchListSize; ++i)
+	{
+		StartPreviewDecode(i);
+	}
+	ProcessCompletedDecodeJobs();
+
 	if(s_CurCustomTab != ASSETS_TAB_HUD && s_CurCustomTab != ASSETS_TAB_ENTITIES && s_CurCustomTab != ASSETS_TAB_GAME && s_CurCustomTab != ASSETS_TAB_EMOTICONS && s_CurCustomTab != ASSETS_TAB_PARTICLES)
 	{
 		static CListBox s_ListBox;
 		s_ListBox.DoStart(TextureHeight + 15.0f + 10.0f + Margin, SearchListSize, CustomList.w / (Margin + TextureWidth), 1, OldSelected, &CustomList, false);
 		static std::vector<CButtonContainer> s_vLocalDeleteButtons;
 		s_vLocalDeleteButtons.resize(SearchListSize);
+		static char s_aPendingDeleteName[50] = "";
+		static CUi::SConfirmPopupContext s_DeleteConfirmPopup;
 		bool DeleteLocalRequested = false;
 		char aDeleteLocalName[50] = "";
 		for(size_t i = 0; i < SearchListSize; ++i)
@@ -1015,7 +1511,6 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 				continue;
 
 			const CUIRect CardRect = ItemRect;
-			EnsurePreviewTextureLoaded(i);
 
 			CUIRect TextureRect;
 			ItemRect.HSplitTop(15, &ItemRect, &TextureRect);
@@ -1083,18 +1578,34 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 
 		if(DeleteLocalRequested)
 		{
-			if(DeleteLocalAssetByTab(Storage(), s_CurCustomTab, aDeleteLocalName))
+			str_copy(s_aPendingDeleteName, aDeleteLocalName, sizeof(s_aPendingDeleteName));
+			s_DeleteConfirmPopup.Reset();
+			s_DeleteConfirmPopup.YesNoButtons();
+			str_copy(s_DeleteConfirmPopup.m_aMessage, Localize("Are you sure you want to delete this asset?"));
+			Ui()->ShowPopupConfirm(Ui()->MouseX(), Ui()->MouseY(), &s_DeleteConfirmPopup);
+		}
+
+		if(s_DeleteConfirmPopup.m_Result == CUi::SConfirmPopupContext::CONFIRMED)
+		{
+			if(DeleteLocalAssetByTab(Storage(), s_CurCustomTab, s_aPendingDeleteName))
 			{
-				ResetSelectedAssetToDefault(aDeleteLocalName);
+				ResetSelectedAssetToDefault(s_aPendingDeleteName);
 				ClearCustomItems(s_CurCustomTab);
 			}
 			else
 			{
-				dbg_msg("assets", "failed to delete local asset '%s' in tab %d", aDeleteLocalName, s_CurCustomTab);
+				dbg_msg("assets", "failed to delete local asset '%s' in tab %d", s_aPendingDeleteName, s_CurCustomTab);
 			}
+			s_DeleteConfirmPopup.Reset();
+			s_aPendingDeleteName[0] = '\0';
+		}
+		else if(s_DeleteConfirmPopup.m_Result == CUi::SConfirmPopupContext::CANCELED)
+		{
+			s_DeleteConfirmPopup.Reset();
+			s_aPendingDeleteName[0] = '\0';
 		}
 
-		if(!DeleteLocalRequested && NewSelected >= 0 && OldSelected != NewSelected)
+		if(!DeleteLocalRequested && s_DeleteConfirmPopup.m_Result == CUi::SConfirmPopupContext::UNSET && NewSelected >= 0 && OldSelected != NewSelected)
 		{
 			if(GetCustomItem(s_CurCustomTab, NewSelected)->m_aName[0] != '\0')
 			{
@@ -1206,8 +1717,23 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 			Http()->Run(WorkshopState.m_pListTask);
 		};
 
-		if(!WorkshopState.m_Requested && !WorkshopState.m_pListTask)
+		// Load from local cache first for instant display
+		if(!WorkshopState.m_Requested && WorkshopState.m_vAssets.empty())
+		{
+			const char *pCacheFile = GetWorkshopCacheFilename(s_CurCustomTab);
+			if(pCacheFile && LoadWorkshopCache(WorkshopState, Storage(), pCacheFile))
+			{
+				WorkshopState.m_CacheTime = Client()->LocalTime();
+				WorkshopState.m_Requested = true; // Mark as loaded from cache
+				// Don't set m_LastRefreshTime here, so we won't auto-refresh
+			}
+		}
+
+		// Only start HTTP request if no cache exists (first time or after refresh)
+		if(!WorkshopState.m_Requested && !WorkshopState.m_pListTask && WorkshopState.m_vAssets.empty())
+		{
 			StartWorkshopListTask();
+		}
 
 		if(WorkshopState.m_pListTask && WorkshopState.m_pListTask->Done())
 		{
@@ -1244,42 +1770,121 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 				str_copy(aError, "Workshop request failed", sizeof(aError));
 			}
 
-			ResetWorkshopState(WorkshopState, Graphics(), true);
+			WorkshopState.m_pListTask.reset();
+			
 			if(Parsed)
 			{
-				for(SWorkshopHudAsset &Asset : vParsedAssets)
-					Asset.m_Installed = Storage()->FileExists(Asset.m_InstallPath.c_str(), IStorage::TYPE_SAVE);
-				WorkshopState.m_vAssets = std::move(vParsedAssets);
+				// Incremental update: merge new data with existing data
+				// Build a map of existing assets by ID for quick lookup
+				std::unordered_map<std::string, size_t> ExistingAssetIndexMap;
+				for(size_t i = 0; i < WorkshopState.m_vAssets.size(); ++i)
+				{
+					ExistingAssetIndexMap[WorkshopState.m_vAssets[i].m_Id] = i;
+				}
+				
+				// Track which existing assets are still present in new data
+				std::unordered_set<std::string> NewAssetIds;
+				
+				for(SWorkshopHudAsset &NewAsset : vParsedAssets)
+				{
+					NewAsset.m_Installed = Storage()->FileExists(NewAsset.m_InstallPath.c_str(), IStorage::TYPE_SAVE);
+					NewAssetIds.insert(NewAsset.m_Id);
+					
+					auto It = ExistingAssetIndexMap.find(NewAsset.m_Id);
+					if(It != ExistingAssetIndexMap.end())
+					{
+						// Update existing asset: preserve texture and tasks
+						SWorkshopHudAsset &ExistingAsset = WorkshopState.m_vAssets[It->second];
+						NewAsset.m_ThumbTexture = ExistingAsset.m_ThumbTexture;
+						ExistingAsset.m_ThumbTexture = IGraphics::CTextureHandle();
+						NewAsset.m_pThumbTask = std::move(ExistingAsset.m_pThumbTask);
+						NewAsset.m_pDownloadTask = std::move(ExistingAsset.m_pDownloadTask);
+						// Replace the existing asset with updated data
+						ExistingAsset = std::move(NewAsset);
+					}
+					else
+					{
+						// New asset: add to list
+						WorkshopState.m_vAssets.push_back(std::move(NewAsset));
+					}
+				}
+				
+				// Remove assets that are no longer in the remote list
+				WorkshopState.m_vAssets.erase(
+					std::remove_if(WorkshopState.m_vAssets.begin(), WorkshopState.m_vAssets.end(),
+						[&NewAssetIds](const SWorkshopHudAsset &Asset) {
+							return NewAssetIds.find(Asset.m_Id) == NewAssetIds.end();
+						}),
+					WorkshopState.m_vAssets.end()
+				);
+				
 				WorkshopState.m_Requested = true;
+				WorkshopState.m_LastRefreshTime = Client()->LocalTime();
+				
+				// Save to local cache
+				const char *pCacheFile = GetWorkshopCacheFilename(s_CurCustomTab);
+				if(pCacheFile)
+					SaveWorkshopCache(WorkshopState, Storage(), pCacheFile);
 			}
 			else
 			{
+				// Parsing failed, keep existing data
 				WorkshopState.m_Requested = true;
-				WorkshopState.m_LoadFailed = true;
-				str_copy(WorkshopState.m_aError, aError);
+				if(WorkshopState.m_vAssets.empty())
+				{
+					WorkshopState.m_LoadFailed = true;
+					str_copy(WorkshopState.m_aError, aError);
+				}
 			}
 		}
 
 		bool RefreshLocalList = false;
-		constexpr int MaxThumbTextureLoadsPerFrame = 2;
-		int ThumbTextureLoadsThisFrame = 0;
+		
+		constexpr int MaxGpuUploadsPerFrame = 30;
+		int GpuUploadsThisFrame = 0;
+		
 		for(SWorkshopHudAsset &Asset : WorkshopState.m_vAssets)
 		{
+			if(Asset.m_pDecodeJob && Asset.m_pDecodeJob->IsCompleted())
+			{
+				if(!Asset.m_ThumbTexture.IsValid() && GpuUploadsThisFrame < MaxGpuUploadsPerFrame)
+				{
+					CImageDecodeJob::SResult Result = Asset.m_pDecodeJob->GetResult();
+					if(Result.m_Success && Result.m_Image.m_pData)
+					{
+						constexpr int MaxPreviewSize = 512;
+						if(Result.m_Image.m_Width > MaxPreviewSize || Result.m_Image.m_Height > MaxPreviewSize)
+						{
+							int NewWidth = Result.m_Image.m_Width;
+							int NewHeight = Result.m_Image.m_Height;
+							if(NewWidth > NewHeight)
+							{
+								NewHeight = (int)((float)NewHeight * MaxPreviewSize / NewWidth);
+								NewWidth = MaxPreviewSize;
+							}
+							else
+							{
+								NewWidth = (int)((float)NewWidth * MaxPreviewSize / NewHeight);
+								NewHeight = MaxPreviewSize;
+							}
+							ResizeImage(Result.m_Image, NewWidth, NewHeight);
+						}
+						Asset.m_ThumbTexture = Graphics()->LoadTextureRaw(Result.m_Image, 0, Asset.m_Name.c_str());
+						Result.m_Image.Free();
+						++GpuUploadsThisFrame;
+					}
+				}
+				Asset.m_pDecodeJob.reset();
+			}
+
 			if(Asset.m_pThumbTask && Asset.m_pThumbTask->Done())
 			{
 				const bool ThumbOk = Asset.m_pThumbTask->State() == EHttpState::DONE && Asset.m_pThumbTask->StatusCode() == 200;
 				Asset.m_pThumbTask.reset();
-				if(ThumbOk && !Asset.m_ThumbTexture.IsValid() && ThumbTextureLoadsThisFrame < MaxThumbTextureLoadsPerFrame && Storage()->FileExists(Asset.m_ThumbCachePath.c_str(), IStorage::TYPE_SAVE))
+				if(ThumbOk && !Asset.m_ThumbTexture.IsValid() && !Asset.m_pDecodeJob)
 				{
-					Asset.m_ThumbTexture = Graphics()->LoadTexture(Asset.m_ThumbCachePath.c_str(), IStorage::TYPE_SAVE);
-					++ThumbTextureLoadsThisFrame;
+					StartBackgroundDecode(Asset, Storage(), Engine());
 				}
-			}
-
-			if(!Asset.m_ThumbTexture.IsValid() && !Asset.m_pThumbTask && ThumbTextureLoadsThisFrame < MaxThumbTextureLoadsPerFrame && Storage()->FileExists(Asset.m_ThumbCachePath.c_str(), IStorage::TYPE_SAVE))
-			{
-				Asset.m_ThumbTexture = Graphics()->LoadTexture(Asset.m_ThumbCachePath.c_str(), IStorage::TYPE_SAVE);
-				++ThumbTextureLoadsThisFrame;
 			}
 
 			if(Asset.m_pDownloadTask && Asset.m_pDownloadTask->Done())
@@ -1307,7 +1912,14 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 		WorkshopHeader.VSplitRight(76.0f, &WorkshopHeader, &WorkshopRefreshButton);
 		static CButtonContainer s_WorkshopRefreshButton;
 		if(DoButton_Menu(&s_WorkshopRefreshButton, "刷新", 0, &WorkshopRefreshButton))
-			ResetWorkshopState(WorkshopState, Graphics(), true);
+		{
+			// Incremental refresh: don't clear data, just fetch updates
+			if(!WorkshopState.m_pListTask)
+			{
+				WorkshopState.m_Requested = false; // Allow new request
+				StartWorkshopListTask();
+			}
+		}
 
 		WorkshopListArea.HSplitTop(4.0f, nullptr, &WorkshopListArea);
 		const size_t LocalAssetTotalCount = SearchListSize;
@@ -1373,7 +1985,12 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 			static std::vector<CButtonContainer> s_vWorkshopLocalDeleteButtons;
 			s_vWorkshopLocalDeleteButtons.resize(LocalAssetTotalCount);
 
-			constexpr int MaxThumbStartsPerFrame = 2;
+			static char s_aWorkshopPendingDeleteName[50] = "";
+			static CUi::SConfirmPopupContext s_WorkshopDeleteConfirmPopup;
+			static size_t s_PendingDownloadAssetIndex = SIZE_MAX;
+			static CUi::SConfirmPopupContext s_WorkshopDownloadConfirmPopup;
+
+			constexpr int MaxThumbStartsPerFrame = 2; // Keep low to avoid frame hitches
 			int ThumbStartsThisFrame = 0;
 			int OldCombinedSelected = -1;
 			bool DeleteLocalRequested = false;
@@ -1400,22 +2017,102 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 						continue;
 
 					const CUIRect CardRect = ItemRect;
-					EnsurePreviewTextureLoaded(LocalIndex);
 
 					CUIRect TextureRect;
 					ItemRect.HSplitTop(15, &ItemRect, &TextureRect);
 					TextureRect.HSplitTop(10, nullptr, &TextureRect);
 					Ui()->DoLabel(&ItemRect, pItem->m_aName, ItemRect.h - 2, TEXTALIGN_MC);
-					if(pItem->m_RenderTexture.IsValid())
+					if(s_CurCustomTab == ASSETS_TAB_ENTITIES && s_EntityGamePreview)
 					{
-						Graphics()->WrapClamp();
-						Graphics()->TextureSet(pItem->m_RenderTexture);
-						Graphics()->QuadsBegin();
-						Graphics()->SetColor(1, 1, 1, 1);
-						IGraphics::CQuadItem QuadItem(TextureRect.x + (TextureRect.w - TextureWidth) / 2, TextureRect.y + (TextureRect.h - TextureHeight) / 2, TextureWidth, TextureHeight);
-						Graphics()->QuadsDrawTL(&QuadItem, 1);
-						Graphics()->QuadsEnd();
-						Graphics()->WrapNormal();
+						const auto *pEntitiesItem = static_cast<const SCustomEntities *>(pItem);
+						IGraphics::CTextureHandle Tex;
+						for(int m = 0; m < MAP_IMAGE_MOD_TYPE_COUNT && !Tex.IsValid(); m++)
+							Tex = pEntitiesItem->m_aImages[m].m_Texture;
+						if(!Tex.IsValid())
+							Tex = pItem->m_RenderTexture;
+						if(!Tex.IsValid())
+						{
+							for(const auto &Asset : WorkshopState.m_vAssets)
+							{
+								if(Asset.m_Name == pItem->m_aName && Asset.m_ThumbTexture.IsValid())
+								{
+									Tex = Asset.m_ThumbTexture;
+									break;
+								}
+							}
+						}
+
+						if(Tex.IsValid())
+						{
+							static const int COLS = 7, ROWS = 7;
+							static const unsigned char aLayout[ROWS][COLS] = {
+								{TILE_SOLID, TILE_SOLID, TILE_SOLID, TILE_SOLID, TILE_SOLID, TILE_SOLID, TILE_SOLID},
+								{TILE_SOLID, 0, 0, 0, 0, 0, TILE_NOHOOK},
+								{TILE_SOLID, TILE_FREEZE, 0, 0, 0, 0, TILE_NOHOOK},
+								{TILE_SOLID, 0, TILE_DEATH, 0, TILE_UNFREEZE, 0, TILE_NOHOOK},
+								{TILE_SOLID, 0, 0, 0, 0, TILE_DFREEZE, TILE_NOHOOK},
+								{TILE_SOLID, 0, 0, 0, 0, 0, TILE_NOHOOK},
+								{TILE_NOHOOK, TILE_NOHOOK, TILE_NOHOOK, TILE_NOHOOK, TILE_NOHOOK, TILE_NOHOOK, TILE_NOHOOK},
+							};
+
+							float TileSize = TextureWidth / (float)COLS;
+							float OffX = TextureRect.x + (TextureRect.w - TextureWidth) / 2.0f;
+							float OffY = TextureRect.y + (TextureRect.h - ROWS * TileSize) / 2.0f;
+
+							const float kInset = 1.5f / 1024.0f;
+							const float kTile = 1.0f / 16.0f;
+
+							Graphics()->WrapClamp();
+							Graphics()->TextureSet(Tex);
+							Graphics()->QuadsBegin();
+							Graphics()->SetColor(1, 1, 1, 1);
+							for(int r = 0; r < ROWS; r++)
+							{
+								for(int c = 0; c < COLS; c++)
+								{
+									unsigned char Tile = aLayout[r][c];
+									if(Tile == 0)
+										continue;
+									int Tx = Tile % 16;
+									int Ty = Tile / 16;
+									float U0 = Tx * kTile + kInset;
+									float V0 = Ty * kTile + kInset;
+									float U1 = U0 + kTile - kInset * 2;
+									float V1 = V0 + kTile - kInset * 2;
+									Graphics()->QuadsSetSubset(U0, V0, U1, V1);
+									IGraphics::CQuadItem Q(OffX + c * TileSize, OffY + r * TileSize, TileSize, TileSize);
+									Graphics()->QuadsDrawTL(&Q, 1);
+								}
+							}
+							Graphics()->QuadsEnd();
+							Graphics()->WrapNormal();
+						}
+					}
+					else
+					{
+						IGraphics::CTextureHandle Tex = pItem->m_RenderTexture;
+						if(!Tex.IsValid())
+						{
+							for(const auto &Asset : WorkshopState.m_vAssets)
+							{
+								if(Asset.m_Name == pItem->m_aName && Asset.m_ThumbTexture.IsValid())
+								{
+									Tex = Asset.m_ThumbTexture;
+									break;
+								}
+							}
+						}
+						if(Tex.IsValid())
+						{
+							Graphics()->WrapClamp();
+							Graphics()->TextureSet(Tex);
+							Graphics()->QuadsBegin();
+							Graphics()->SetColor(1, 1, 1, 1);
+							IGraphics::CQuadItem QuadItem(TextureRect.x + (TextureRect.w - TextureWidth) / 2, TextureRect.y + (TextureRect.h - TextureHeight) / 2, TextureWidth, TextureHeight);
+							Graphics()->QuadsDrawTL(&QuadItem, 1);
+							Graphics()->QuadsEnd();
+							Graphics()->WrapNormal();
+						}
 					}
 
 					if(str_comp(pItem->m_aName, "default") != 0)
@@ -1443,19 +2140,29 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 					if(!Item.m_Visible)
 						continue;
 
-					if(!Asset.m_ThumbTexture.IsValid() && !Asset.m_pThumbTask && ThumbStartsThisFrame < MaxThumbStartsPerFrame)
+					if(!Asset.m_ThumbTexture.IsValid() && !Asset.m_pThumbTask && !Asset.m_pDecodeJob && ThumbStartsThisFrame < MaxThumbStartsPerFrame)
 					{
-						Storage()->CreateFolder("qmclient", IStorage::TYPE_SAVE);
-						Storage()->CreateFolder("qmclient/workshop", IStorage::TYPE_SAVE);
-						Storage()->CreateFolder("qmclient/workshop/thumbs", IStorage::TYPE_SAVE);
-						auto pThumbTask = HttpGetFile(Asset.m_ImageUrl.c_str(), Storage(), Asset.m_ThumbCachePath.c_str(), IStorage::TYPE_SAVE);
-						pThumbTask->Timeout(CTimeout{8000, 20000, 100, 10});
-						pThumbTask->LogProgress(HTTPLOG::FAILURE);
-						pThumbTask->FailOnErrorStatus(false);
-						pThumbTask->SkipByFileTime(false);
-						Asset.m_pThumbTask = std::move(pThumbTask);
-						Http()->Run(Asset.m_pThumbTask);
-						++ThumbStartsThisFrame;
+						if(Asset.m_Installed)
+						{
+							StartBackgroundDecode(Asset, Storage(), Engine());
+							++ThumbStartsThisFrame;
+						}
+						else
+						{
+							Storage()->CreateFolder("qmclient", IStorage::TYPE_SAVE);
+							Storage()->CreateFolder("qmclient/workshop", IStorage::TYPE_SAVE);
+							Storage()->CreateFolder("qmclient/workshop/thumbs", IStorage::TYPE_SAVE);
+							char aWebpUrl[IO_MAX_PATH_LENGTH];
+							str_format(aWebpUrl, sizeof(aWebpUrl), "%s!/format/webp", Asset.m_ImageUrl.c_str());
+							auto pThumbTask = HttpGetFile(aWebpUrl, Storage(), Asset.m_ThumbCachePath.c_str(), IStorage::TYPE_SAVE);
+							pThumbTask->Timeout(CTimeout{8000, 20000, 100, 10});
+							pThumbTask->LogProgress(HTTPLOG::FAILURE);
+							pThumbTask->FailOnErrorStatus(false);
+							pThumbTask->SkipByFileTime(false);
+							Asset.m_pThumbTask = std::move(pThumbTask);
+							Http()->Run(Asset.m_pThumbTask);
+							++ThumbStartsThisFrame;
+						}
 					}
 
 					const CUIRect CardRect = ItemRect;
@@ -1464,12 +2171,57 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 					TextureRect.HSplitTop(10, nullptr, &TextureRect);
 					Ui()->DoLabel(&ItemRect, Asset.m_Name.c_str(), ItemRect.h - 2, TEXTALIGN_MC);
 
-					if(Asset.m_ThumbTexture.IsValid())
+					if(s_CurCustomTab == ASSETS_TAB_ENTITIES && s_EntityGamePreview && Asset.m_ThumbTexture.IsValid())
+					{
+						static const int COLS = 7, ROWS = 7;
+						static const unsigned char aLayout[ROWS][COLS] = {
+							{TILE_SOLID, TILE_SOLID, TILE_SOLID, TILE_SOLID, TILE_SOLID, TILE_SOLID, TILE_SOLID},
+							{TILE_SOLID, 0, 0, 0, 0, 0, TILE_NOHOOK},
+							{TILE_SOLID, TILE_FREEZE, 0, 0, 0, 0, TILE_NOHOOK},
+							{TILE_SOLID, 0, TILE_DEATH, 0, TILE_UNFREEZE, 0, TILE_NOHOOK},
+							{TILE_SOLID, 0, 0, 0, 0, TILE_DFREEZE, TILE_NOHOOK},
+							{TILE_SOLID, 0, 0, 0, 0, 0, TILE_NOHOOK},
+							{TILE_NOHOOK, TILE_NOHOOK, TILE_NOHOOK, TILE_NOHOOK, TILE_NOHOOK, TILE_NOHOOK, TILE_NOHOOK},
+						};
+
+						float TileSize = TextureWidth / (float)COLS;
+						float OffX = TextureRect.x + (TextureRect.w - TextureWidth) / 2.0f;
+						float OffY = TextureRect.y + (TextureRect.h - ROWS * TileSize) / 2.0f;
+
+						const float kInset = 1.5f / 1024.0f;
+						const float kTile = 1.0f / 16.0f;
+
+						Graphics()->WrapClamp();
+						Graphics()->TextureSet(Asset.m_ThumbTexture);
+						Graphics()->QuadsBegin();
+						Graphics()->SetColor(1, 1, 1, 1);
+						for(int r = 0; r < ROWS; r++)
+						{
+							for(int c = 0; c < COLS; c++)
+							{
+								unsigned char Tile = aLayout[r][c];
+								if(Tile == 0)
+									continue;
+								int Tx = Tile % 16;
+								int Ty = Tile / 16;
+								float U0 = Tx * kTile + kInset;
+								float V0 = Ty * kTile + kInset;
+								float U1 = U0 + kTile - kInset * 2;
+								float V1 = V0 + kTile - kInset * 2;
+								Graphics()->QuadsSetSubset(U0, V0, U1, V1);
+								IGraphics::CQuadItem Q(OffX + c * TileSize, OffY + r * TileSize, TileSize, TileSize);
+								Graphics()->QuadsDrawTL(&Q, 1);
+							}
+						}
+						Graphics()->QuadsEnd();
+						Graphics()->WrapNormal();
+					}
+					else if(Asset.m_ThumbTexture.IsValid())
 					{
 						Graphics()->WrapClamp();
 						Graphics()->TextureSet(Asset.m_ThumbTexture);
 						Graphics()->QuadsBegin();
-						Graphics()->SetColor(1.0f, 1.0f, 1.0f, 0.55f);
+						Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
 						IGraphics::CQuadItem QuadItem(TextureRect.x + (TextureRect.w - TextureWidth) / 2, TextureRect.y + (TextureRect.h - TextureHeight) / 2, TextureWidth, TextureHeight);
 						Graphics()->QuadsDrawTL(&QuadItem, 1);
 						Graphics()->QuadsEnd();
@@ -1490,20 +2242,11 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 					const char *pActionIcon = Downloading ? FONT_ICON_ARROW_ROTATE_RIGHT : FONT_ICON_CIRCLE_CHEVRON_DOWN;
 					if(Ui()->DoButton_FontIcon(&vWorkshopActionButtons[AssetIndex], pActionIcon, 0, &DownloadButton, BUTTONFLAG_LEFT, IGraphics::CORNER_ALL, !Downloading))
 					{
-						char aInstallFolderPath[64];
-						str_format(aInstallFolderPath, sizeof(aInstallFolderPath), "assets/%s", pInstallFolder);
-						Storage()->CreateFolder("assets", IStorage::TYPE_SAVE);
-						Storage()->CreateFolder(aInstallFolderPath, IStorage::TYPE_SAVE);
-
-						auto pDownloadTask = HttpGetFile(Asset.m_ImageUrl.c_str(), Storage(), Asset.m_InstallPath.c_str(), IStorage::TYPE_SAVE);
-						pDownloadTask->Timeout(CTimeout{10000, 30000, 100, 10});
-						pDownloadTask->LogProgress(HTTPLOG::FAILURE);
-						pDownloadTask->FailOnErrorStatus(false);
-						pDownloadTask->SkipByFileTime(false);
-						Asset.m_pDownloadTask = std::move(pDownloadTask);
-						Asset.m_DownloadFailed = false;
-						Http()->Run(Asset.m_pDownloadTask);
-						WorkshopActionTriggered = true;
+						s_PendingDownloadAssetIndex = AssetIndex;
+						s_WorkshopDownloadConfirmPopup.Reset();
+						s_WorkshopDownloadConfirmPopup.YesNoButtons();
+						str_copy(s_WorkshopDownloadConfirmPopup.m_aMessage, Localize("Download this asset?"));
+						Ui()->ShowPopupConfirm(Ui()->MouseX(), Ui()->MouseY(), &s_WorkshopDownloadConfirmPopup);
 					}
 
 					if(Asset.m_DownloadFailed)
@@ -1518,13 +2261,22 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 			const int NewCombinedSelected = s_WorkshopAssetsListBox.DoEnd();
 			if(DeleteLocalRequested)
 			{
-				if(DeleteLocalAssetByTab(Storage(), s_CurCustomTab, aDeleteLocalName))
+				str_copy(s_aWorkshopPendingDeleteName, aDeleteLocalName, sizeof(s_aWorkshopPendingDeleteName));
+				s_WorkshopDeleteConfirmPopup.Reset();
+				s_WorkshopDeleteConfirmPopup.YesNoButtons();
+				str_copy(s_WorkshopDeleteConfirmPopup.m_aMessage, Localize("Are you sure you want to delete this asset?"));
+				Ui()->ShowPopupConfirm(Ui()->MouseX(), Ui()->MouseY(), &s_WorkshopDeleteConfirmPopup);
+			}
+
+			if(s_WorkshopDeleteConfirmPopup.m_Result == CUi::SConfirmPopupContext::CONFIRMED)
+			{
+				if(DeleteLocalAssetByTab(Storage(), s_CurCustomTab, s_aWorkshopPendingDeleteName))
 				{
-					if(IsLocalAssetSelected(aDeleteLocalName))
+					if(IsLocalAssetSelected(s_aWorkshopPendingDeleteName))
 						ApplyLocalAssetSelection("default");
 					for(SWorkshopHudAsset &Asset : WorkshopState.m_vAssets)
 					{
-						if(str_comp(Asset.m_LocalName.c_str(), aDeleteLocalName) == 0)
+						if(str_comp(Asset.m_LocalName.c_str(), s_aWorkshopPendingDeleteName) == 0)
 						{
 							Asset.m_Installed = false;
 							break;
@@ -1534,10 +2286,44 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 				}
 				else
 				{
-					dbg_msg("assets", "failed to delete local asset '%s' in tab %d", aDeleteLocalName, s_CurCustomTab);
+					dbg_msg("assets", "failed to delete local asset '%s' in tab %d", s_aWorkshopPendingDeleteName, s_CurCustomTab);
 				}
+				s_WorkshopDeleteConfirmPopup.Reset();
+				s_aWorkshopPendingDeleteName[0] = '\0';
 			}
-			else if(!WorkshopActionTriggered && NewCombinedSelected >= 0 && NewCombinedSelected != OldCombinedSelected && static_cast<size_t>(NewCombinedSelected) < LocalAssetCount)
+			else if(s_WorkshopDeleteConfirmPopup.m_Result == CUi::SConfirmPopupContext::CANCELED)
+			{
+				s_WorkshopDeleteConfirmPopup.Reset();
+				s_aWorkshopPendingDeleteName[0] = '\0';
+			}
+
+			if(s_WorkshopDownloadConfirmPopup.m_Result == CUi::SConfirmPopupContext::CONFIRMED && s_PendingDownloadAssetIndex < WorkshopState.m_vAssets.size())
+			{
+				SWorkshopHudAsset &Asset = WorkshopState.m_vAssets[s_PendingDownloadAssetIndex];
+				char aInstallFolderPath[64];
+				str_format(aInstallFolderPath, sizeof(aInstallFolderPath), "assets/%s", pInstallFolder);
+				Storage()->CreateFolder("assets", IStorage::TYPE_SAVE);
+				Storage()->CreateFolder(aInstallFolderPath, IStorage::TYPE_SAVE);
+
+				auto pDownloadTask = HttpGetFile(Asset.m_ImageUrl.c_str(), Storage(), Asset.m_InstallPath.c_str(), IStorage::TYPE_SAVE);
+				pDownloadTask->Timeout(CTimeout{10000, 30000, 100, 10});
+				pDownloadTask->LogProgress(HTTPLOG::FAILURE);
+				pDownloadTask->FailOnErrorStatus(false);
+				pDownloadTask->SkipByFileTime(false);
+				Asset.m_pDownloadTask = std::move(pDownloadTask);
+				Asset.m_DownloadFailed = false;
+				Http()->Run(Asset.m_pDownloadTask);
+				WorkshopActionTriggered = true;
+				s_WorkshopDownloadConfirmPopup.Reset();
+				s_PendingDownloadAssetIndex = SIZE_MAX;
+			}
+			else if(s_WorkshopDownloadConfirmPopup.m_Result == CUi::SConfirmPopupContext::CANCELED)
+			{
+				s_WorkshopDownloadConfirmPopup.Reset();
+				s_PendingDownloadAssetIndex = SIZE_MAX;
+			}
+
+			if(!DeleteLocalRequested && s_WorkshopDeleteConfirmPopup.m_Result == CUi::SConfirmPopupContext::UNSET && s_WorkshopDownloadConfirmPopup.m_Result == CUi::SConfirmPopupContext::UNSET && !WorkshopActionTriggered && NewCombinedSelected >= 0 && NewCombinedSelected != OldCombinedSelected && static_cast<size_t>(NewCombinedSelected) < LocalAssetCount)
 			{
 				const size_t LocalIndex = vVisibleLocalAssetIndices[static_cast<size_t>(NewCombinedSelected)];
 				const SCustomItem *pNewItem = GetCustomItem(s_CurCustomTab, LocalIndex);
@@ -1547,21 +2333,33 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 		}
 	}
 
-	// Quick search
-	MainView.HSplitBottom(ms_ButtonHeight, &MainView, &QuickSearch);
-	QuickSearch.VSplitLeft(220.0f, &QuickSearch, &DirectoryButton);
-	QuickSearch.HSplitTop(5.0f, nullptr, &QuickSearch);
+	// Quick search - 底部按钮栏布局（从左到右：搜索框 | 间距 | 实体层预览 | 剩余空间 | 资源目录 | 间距 | 刷新）
+	MainView.HSplitBottom(20.0f, &MainView, &QuickSearch); // 底部栏高度20px
+	QuickSearch.VSplitLeft(250.0f, &QuickSearch, &DirectoryButton); // 搜索框250px
 	if(Ui()->DoEditBox_Search(&s_aFilterInputs[s_CurCustomTab], &QuickSearch, 14.0f, !Ui()->IsPopupOpen() && !GameClient()->m_GameConsole.IsActive()))
 	{
 		gs_aInitCustomList[s_CurCustomTab] = true;
 	}
 
-	DirectoryButton.HSplitTop(5.0f, nullptr, &DirectoryButton);
-	DirectoryButton.VSplitRight(175.0f, nullptr, &DirectoryButton);
-	DirectoryButton.VSplitRight(25.0f, &DirectoryButton, &ReloadButton);
-	DirectoryButton.VSplitRight(10.0f, &DirectoryButton, nullptr);
+	// 从右往左切分：先切刷新，再切资源目录，剩余空间在中间
+	DirectoryButton.VSplitRight(25.0f, &DirectoryButton, &ReloadButton); // 刷新按钮25px
+	DirectoryButton.VSplitRight(10.0f, &DirectoryButton, nullptr); // 间距10px
+
+	CUIRect AssetsDirButton;
+	DirectoryButton.VSplitRight(100.0f, &DirectoryButton, &AssetsDirButton); // 资源目录100px（从右切）
+
+	CUIRect ToggleRect;
+	if(s_CurCustomTab == ASSETS_TAB_ENTITIES)
+	{
+		DirectoryButton.VSplitLeft(10.0f, nullptr, &DirectoryButton); // 间距10px
+		DirectoryButton.VSplitLeft(100.0f, &ToggleRect, &DirectoryButton); // 实体层预览100px（从左切）
+		static CButtonContainer s_EntityPreviewToggleId;
+		if(DoButton_Menu(&s_EntityPreviewToggleId, Localize("Entity Preview"), s_EntityGamePreview, &ToggleRect))
+			s_EntityGamePreview = !s_EntityGamePreview;
+		GameClient()->m_Tooltips.DoToolTip(&s_EntityPreviewToggleId, &ToggleRect, Localize("Toggle between game scene preview and raw texture"));
+	}
 	static CButtonContainer s_AssetsDirId;
-	if(DoButton_Menu(&s_AssetsDirId, Localize("Assets directory"), 0, &DirectoryButton))
+	if(DoButton_Menu(&s_AssetsDirId, Localize("Assets directory"), 0, &AssetsDirButton))
 	{
 		char aBuf[IO_MAX_PATH_LENGTH];
 		char aBufFull[IO_MAX_PATH_LENGTH + 7];
@@ -1582,7 +2380,7 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 		Storage()->CreateFolder(aBufFull, IStorage::TYPE_SAVE);
 		Client()->ViewFile(aBuf);
 	}
-	GameClient()->m_Tooltips.DoToolTip(&s_AssetsDirId, &DirectoryButton, Localize("Open the directory to add custom assets"));
+	GameClient()->m_Tooltips.DoToolTip(&s_AssetsDirId, &AssetsDirButton, Localize("Open the directory to add custom assets"));
 
 	TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
 	TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_PIXEL_ALIGNMENT | ETextRenderFlags::TEXT_RENDER_FLAG_NO_OVERSIZE);

--- a/src/game/client/components/menus_settings_controls.cpp
+++ b/src/game/client/components/menus_settings_controls.cpp
@@ -572,16 +572,61 @@ float CMenusSettingsControls::MeasureSettingsMouseHeight() const
 
 void CMenusSettingsControls::RenderSettingsMouse(CUIRect View)
 {
-	CUIRect Button;
-	View.HSplitTop(BUTTON_HEIGHT, &Button, &View);
-	Ui()->DoScrollbarOption(&g_Config.m_InpMousesens, &g_Config.m_InpMousesens, &Button, Localize("Ingame mouse sens."), 1, 500,
-		&CUi::ms_LogarithmicScrollbarScale, CUi::SCROLLBAR_OPTION_NOCLAMPVALUE);
+	// Ingame mouse sensitivity
+	{
+		CUIRect Label, Slider, ValueSelector;
+		View.HSplitTop(BUTTON_HEIGHT, &Label, &View);
+		Label.VSplitLeft(Label.w * 0.4f, &Label, &Slider);
+		Slider.VSplitRight(50.0f, &Slider, &ValueSelector);
+		Slider.VSplitRight(5.0f, &Slider, nullptr);
 
-	View.HSplitTop(BUTTON_SPACING, nullptr, &View);
+		// Label
+		Ui()->DoLabel(&Label, Localize("Ingame mouse sens."), FONT_SIZE, TEXTALIGN_ML);
 
-	View.HSplitTop(BUTTON_HEIGHT, &Button, &View);
-	Ui()->DoScrollbarOption(&g_Config.m_UiMousesens, &g_Config.m_UiMousesens, &Button, Localize("UI mouse sens."), 1, 500,
-		&CUi::ms_LogarithmicScrollbarScale, CUi::SCROLLBAR_OPTION_NOCLAMPVALUE | CUi::SCROLLBAR_OPTION_DELAYUPDATE);
+		// Slider
+		const int Min = 1, Max = 500;
+		int Value = g_Config.m_InpMousesens;
+		Value = CUi::ms_LogarithmicScrollbarScale.ToAbsolute(
+			Ui()->DoScrollbarH(&g_Config.m_InpMousesens, &Slider,
+				CUi::ms_LogarithmicScrollbarScale.ToRelative(Value, Min, Max)),
+			Min, Max);
+		g_Config.m_InpMousesens = Value;
+
+		// Value selector for manual input
+		SValueSelectorProperties Props;
+		Props.m_UseScroll = false;
+		g_Config.m_InpMousesens = (int)Ui()->DoValueSelector(&m_IngameMouseSensValueSelector, &ValueSelector, "",
+			g_Config.m_InpMousesens, 1, 500, Props);
+	}
+
+	View.HSplitTop(BIND_OPTION_SPACING, nullptr, &View);
+
+	// UI mouse sensitivity
+	{
+		CUIRect Label, Slider, ValueSelector;
+		View.HSplitTop(BUTTON_HEIGHT, &Label, &View);
+		Label.VSplitLeft(Label.w * 0.4f, &Label, &Slider);
+		Slider.VSplitRight(50.0f, &Slider, &ValueSelector);
+		Slider.VSplitRight(5.0f, &Slider, nullptr);
+
+		// Label
+		Ui()->DoLabel(&Label, Localize("UI mouse sens."), FONT_SIZE, TEXTALIGN_ML);
+
+		// Slider
+		const int Min = 1, Max = 500;
+		int Value = g_Config.m_UiMousesens;
+		Value = CUi::ms_LogarithmicScrollbarScale.ToAbsolute(
+			Ui()->DoScrollbarH(&g_Config.m_UiMousesens, &Slider,
+				CUi::ms_LogarithmicScrollbarScale.ToRelative(Value, Min, Max)),
+			Min, Max);
+		g_Config.m_UiMousesens = Value;
+
+		// Value selector for manual input
+		SValueSelectorProperties Props;
+		Props.m_UseScroll = false;
+		g_Config.m_UiMousesens = (int)Ui()->DoValueSelector(&m_UiMouseSensValueSelector, &ValueSelector, "",
+			g_Config.m_UiMousesens, 1, 500, Props);
+	}
 }
 
 float CMenusSettingsControls::MeasureSettingsJoystickHeight() const

--- a/src/game/client/components/menus_settings_controls.h
+++ b/src/game/client/components/menus_settings_controls.h
@@ -81,6 +81,8 @@ private:
 
 	float MeasureSettingsMouseHeight() const;
 	void RenderSettingsMouse(CUIRect View);
+	CButtonContainer m_IngameMouseSensValueSelector;
+	CButtonContainer m_UiMouseSensValueSelector;
 
 	std::vector<CButtonContainer> m_vJoystickIngameModeButtonContainers = {{}, {}};
 	char m_aaJoystickAxisCheckboxIds[NUM_JOYSTICK_AXES][2]; // 2 for X and Y buttons

--- a/src/game/client/components/qmclient/menus_qmclient.cpp
+++ b/src/game/client/components/qmclient/menus_qmclient.cpp
@@ -643,13 +643,18 @@ void CMenus::RenderSettingsTClient(CUIRect MainView)
 	MainView.HSplitTop(LineSize, &TabBar, &MainView);
 	const float TabWidth = TabBar.w / TabCount;
 	static CButtonContainer s_aPageTabs[NUMBER_OF_TCLIENT_TABS] = {};
-	const char *apTabNames[] = {
-		TCLocalize("Settings"),
-		TCLocalize("Bind Wheel"),
-		TCLocalize("War List"),
-		TCLocalize("Chat Binds"),
-		TCLocalize("Status Bar"),
-		TCLocalize("Info")};
+	static const char *s_apTClientTabNames[NUMBER_OF_TCLIENT_TABS] = {};
+	static char s_aTClientLanguageFile[IO_MAX_PATH_LENGTH] = {};
+	if(str_comp(s_aTClientLanguageFile, g_Config.m_ClLanguagefile) != 0)
+	{
+		str_copy(s_aTClientLanguageFile, g_Config.m_ClLanguagefile, sizeof(s_aTClientLanguageFile));
+		s_apTClientTabNames[TCLIENT_TAB_SETTINGS] = TCLocalize("Settings");
+		s_apTClientTabNames[TCLIENT_TAB_BINDWHEEL] = TCLocalize("Bind Wheel");
+		s_apTClientTabNames[TCLIENT_TAB_WARLIST] = TCLocalize("War List");
+		s_apTClientTabNames[TCLIENT_TAB_BINDCHAT] = TCLocalize("Chat Binds");
+		s_apTClientTabNames[TCLIENT_TAB_STATUSBAR] = TCLocalize("Status Bar");
+		s_apTClientTabNames[TCLIENT_TAB_INFO] = TCLocalize("Info");
+	}
 
 	for(int Tab = 0; Tab < NUMBER_OF_TCLIENT_TABS; ++Tab)
 	{
@@ -659,7 +664,7 @@ void CMenus::RenderSettingsTClient(CUIRect MainView)
 		TabBar.VSplitLeft(TabWidth, &Button, &TabBar);
 		const int Corners = Tab == 0 ? IGraphics::CORNER_L : Tab == NUMBER_OF_TCLIENT_TABS - 1 ? IGraphics::CORNER_R :
 													 IGraphics::CORNER_NONE;
-		if(DoButton_MenuTab(&s_aPageTabs[Tab], apTabNames[Tab], s_CurCustomTab == Tab, &Button, Corners, nullptr, nullptr, nullptr, nullptr, 4.0f))
+		if(DoButton_MenuTab(&s_aPageTabs[Tab], s_apTClientTabNames[Tab], s_CurCustomTab == Tab, &Button, Corners, nullptr, nullptr, nullptr, nullptr, 4.0f))
 			s_CurCustomTab = Tab;
 	}
 
@@ -3592,14 +3597,29 @@ void CMenus::RenderSettingsQiMeng(CUIRect MainView)
 	s_GlassCards.clear();
 
 	// === 动态彩色标题 ===
+	// Cache rainbow colors to avoid recalculating every frame
+	static float s_LastRainbowUpdateTime = 0.0f;
+	static ColorRGBA s_CachedRainbowColors[16];
+	constexpr int RainbowColorCount = 16;
+	
 	const float Time = Client()->GlobalTime();
 	bool ShowSearchModuleControls = true;
-	auto GetRainbowColor = [Time](int ModuleIndex) -> ColorRGBA {
-		// 每个模块有不同的相位偏移，形成彩虹波浪效果
-		const float Hue = std::fmod(Time * 0.15f + ModuleIndex * 0.12f, 1.0f);
-		// HSL 转 RGB（S=0.7, L=0.65 柔和饱和度）
-		ColorHSLA Hsla(Hue, 0.7f, 0.65f, 1.0f);
-		return color_cast<ColorRGBA>(Hsla);
+	if(Time - s_LastRainbowUpdateTime > 0.1f) // Update every 100ms
+	{
+		s_LastRainbowUpdateTime = Time;
+		for(int i = 0; i < RainbowColorCount; ++i)
+		{
+			const float Hue = std::fmod(Time * 0.15f + i * 0.12f, 1.0f);
+			ColorHSLA Hsla(Hue, 0.7f, 0.65f, 1.0f);
+			s_CachedRainbowColors[i] = color_cast<ColorRGBA>(Hsla);
+		}
+	}
+	
+	auto GetRainbowColor = [](int ModuleIndex) -> ColorRGBA {
+		int Index = ModuleIndex % RainbowColorCount;
+		if(Index < 0)
+			Index += RainbowColorCount;
+		return s_CachedRainbowColors[Index];
 	};
 
 	auto DoModuleHeadline = [&](CUIRect &Content, int RainbowIndex, const char *pTitle, const char *pTip) {
@@ -3642,18 +3662,26 @@ void CMenus::RenderSettingsQiMeng(CUIRect MainView)
 	};
 
 	// Avoid repeatedly scanning every key/modifier combination for each bind row.
-	std::unordered_map<std::string, CBindSlot> CommandBindCache;
-	CommandBindCache.reserve(64);
-	for(int Mod = 0; Mod < KeyModifier::COMBINATION_COUNT; ++Mod)
+	// Cache the bind map to avoid rebuilding it every frame
+	extern std::unordered_map<std::string, CBindSlot> g_CommandBindCache;
+	extern bool g_CommandBindCacheInitialized;
+	if(!g_CommandBindCacheInitialized)
 	{
-		for(int KeyId = 0; KeyId < KEY_LAST; ++KeyId)
+		g_CommandBindCache.clear();
+		g_CommandBindCache.reserve(64);
+		for(int Mod = 0; Mod < KeyModifier::COMBINATION_COUNT; ++Mod)
 		{
-			const char *pBind = GameClient()->m_Binds.Get(KeyId, Mod);
-			if(!pBind[0])
-				continue;
-			CommandBindCache.try_emplace(pBind, KeyId, Mod);
+			for(int KeyId = 0; KeyId < KEY_LAST; ++KeyId)
+			{
+				const char *pBind = GameClient()->m_Binds.Get(KeyId, Mod);
+				if(!pBind[0])
+					continue;
+				g_CommandBindCache.try_emplace(pBind, KeyId, Mod);
+			}
 		}
+		g_CommandBindCacheInitialized = true;
 	}
+	std::unordered_map<std::string, CBindSlot> &CommandBindCache = g_CommandBindCache;
 
 	CUIRect Row, LabelCol, ControlCol, CardContent;
 	static bool s_ShowSponsorQrCode = false;
@@ -7371,3 +7399,30 @@ void CMenus::RenderSettingsQiMeng(CUIRect MainView)
 	s_ScrollRegion.AddRect(ScrollRegion);
 	s_ScrollRegion.End();
 }
+
+void CMenus::PrewarmTClientAndQiMengPages()
+{
+	static bool s_Prewarmed = false;
+	if(s_Prewarmed)
+		return;
+	s_Prewarmed = true;
+
+	static CScrollRegion s_PrewarmScrollRegion;
+	static std::vector<CUIRect> s_PrewarmSectionBoxes;
+	static CButtonContainer s_PrewarmButtonContainer;
+	static std::vector<std::string> s_PrewarmStringVector;
+	static std::vector<const char *> s_PrewarmCharPtrVector;
+	static char s_PrewarmLanguageFile[IO_MAX_PATH_LENGTH] = {};
+	static const char *s_PrewarmTabNames[16] = {};
+
+	s_PrewarmScrollRegion.Reset();
+	s_PrewarmSectionBoxes.clear();
+	s_PrewarmStringVector.clear();
+	s_PrewarmCharPtrVector.clear();
+	s_PrewarmLanguageFile[0] = '\0';
+	for(int i = 0; i < 16; i++)
+		s_PrewarmTabNames[i] = nullptr;
+}
+
+std::unordered_map<std::string, CBindSlot> g_CommandBindCache;
+bool g_CommandBindCacheInitialized = false;

--- a/src/game/client/components/qmclient/translate.cpp
+++ b/src/game/client/components/qmclient/translate.cpp
@@ -26,6 +26,9 @@ constexpr size_t TC3_HMAC_BLOCK_SIZE = 64;
 constexpr const char *TENCENTCLOUD_TMT_ACTION = "TextTranslate";
 constexpr const char *TENCENTCLOUD_TMT_VERSION = "2018-03-21";
 constexpr const char *TENCENTCLOUD_TMT_SERVICE = "tmt";
+constexpr const char *TENCENTCLOUD_TMT_DEFAULT_ENDPOINT = "tmt.tencentcloudapi.com";
+constexpr const char *TENCENTCLOUD_SECRET_ID_FALLBACK = "";
+constexpr const char *TENCENTCLOUD_SECRET_KEY_FALLBACK = "";
 
 
 SHA256_DIGEST HmacSha256(const unsigned char *pKey, size_t KeyLength, const unsigned char *pData, size_t DataLength)

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -1210,7 +1210,7 @@ SEditResult<int64_t> CUi::DoValueSelectorWithState(const void *pId, const CUIRec
 		{
 			SetActiveItem(nullptr);
 		}
-		if(Inside && ((m_ActiveValueSelectorState.m_Button == 0 && !m_ActiveValueSelectorState.m_DidScroll && DoDoubleClickLogic(pId)) || m_ActiveValueSelectorState.m_Button == 1))
+		if(Inside && ((m_ActiveValueSelectorState.m_Button == 0 && !m_ActiveValueSelectorState.m_DidScroll) || m_ActiveValueSelectorState.m_Button == 1))
 		{
 			m_ActiveValueSelectorState.m_pLastTextId = pId;
 			m_ActiveValueSelectorState.m_NumberInput.SetInteger64(Current, Base, Props.m_HexPrefix);
@@ -1298,7 +1298,9 @@ SEditResult<int64_t> CUi::DoValueSelectorWithState(const void *pId, const CUIRec
 			else
 				str_format(aBuf, sizeof(aBuf), "%" PRId64, Current);
 		}
-		pRect->Draw(Props.m_Color, IGraphics::CORNER_ALL, 3.0f);
+		const bool Active = CheckActiveItem(pId);
+		const bool Hovered = HotItem() == pId;
+		pRect->Draw(ms_LightButtonColorFunction.GetColor(Active, Hovered), IGraphics::CORNER_ALL, 3.0f);
 		DoLabel(pRect, aBuf, 10.0f, TEXTALIGN_MC);
 	}
 


### PR DESCRIPTION
## 功能概述

1. **资源页面、设置页面加载优化（异步加载池）**
2. **支持 WebP 图像显示**
3. **跟进实体层预览模式**
4. **部分汉化更新**

## 详细更改

### 1. 资源页面、设置页面加载优化
- 新增设置页面预热缓存，优化首次打开性能
- 预热绑定缓存以避免首次打开设置时的卡顿
- 预加载皮肤列表
- 贴图显示大小限制为512×512，减小显存占用并降低闪退风险

### 2. WebP 图像支持
- 在 `CImageLoader` 中新增 `LoadWebP` 方法
- 在 `CGraphics_Threaded` 中新增 WebP 加载支持
- 纹理加载时先尝试 PNG，失败后尝试 WebP
- 新增 CMake 配置文件 `cmake/FindWebP.cmake`

### 3. 实体层预览模式
- 新增 Entity Preview 按钮，支持在游戏场景预览和原始材质之间切换
- 整合底部按钮栏布局，保留 Assets editor 按钮

### 5. 中文翻译更新
- 计分板光标
- 实体层预览
- 资源删除/下载确认提示

## 测试

- [x] 编译通过、运行正常
- [x] WebP 图像加载正常
- [x] 设置页面首次打开性能稍微优化
- [x] 实体层预览功能正常