### PR TITLE
新增 Qm 在线分布页签并优化 HUD 编辑器与唤醒判定

### DIFF
--- a/data/languages/simplified_chinese.txt
+++ b/data/languages/simplified_chinese.txt
@@ -6318,3 +6318,39 @@ Size presets
 
 Zoom presets
 == 缩放预设
+
+QmClient
+== QmClient
+
+QmClient online distribution
+== QmClient 在线分布
+
+Set a voice server to enable QmClient distribution
+== 需要先配置语音服务器，才能启用 QmClient 在线分布
+
+No active QmClient reports yet
+== 暂无活跃的 QmClient 上报
+
+%d servers, %d users
+== %d 个服务器，%d 个用户
+
+%d servers, %d users, %d dummies
+== %d 个服务器，%d 个用户，%d 个分身
+
+%d user
+== %d 个用户
+
+%d users
+== %d 个用户
+
+%d dummy
+== %d 个分身
+
+%d dummies
+== %d 个分身
+
+Selected server
+== 已选中服务器
+
+Not in the current browser list
+== 不在当前浏览器列表中

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -233,7 +233,7 @@ MACRO_CONFIG_STR(ClDummy7SkinEyes, dummy7_skin_eyes, protocol7::MAX_SKIN_ARRAY_S
 
 MACRO_CONFIG_INT(UiPage, ui_page, 6, 6, 13, CFGFLAG_CLIENT | CFGFLAG_SAVE, "界面页面")
 MACRO_CONFIG_INT(UiSettingsPage, ui_settings_page, 0, 0, 11, CFGFLAG_CLIENT | CFGFLAG_SAVE, "界面设置页面")
-MACRO_CONFIG_INT(UiToolboxPage, ui_toolbox_page, 0, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE, "工具箱页面")
+MACRO_CONFIG_INT(UiToolboxPage, ui_toolbox_page, 0, 0, 3, CFGFLAG_CLIENT | CFGFLAG_SAVE, "工具箱页面")
 MACRO_CONFIG_STR(UiServerAddress, ui_server_address, 1024, "localhost:8303", CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_INSENSITIVE, "界面服务器地址")
 MACRO_CONFIG_INT(UiMousesens, ui_mousesens, 200, 1, 100000, CFGFLAG_SAVE | CFGFLAG_CLIENT, "菜单/编辑器中的鼠标灵敏度")
 MACRO_CONFIG_INT(UiControllerSens, ui_controller_sens, 100, 1, 100000, CFGFLAG_SAVE | CFGFLAG_CLIENT, "菜单/编辑器中的手柄灵敏度")

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -317,64 +317,21 @@ int CControls::SnapInput(int *pData)
 
 		if(g_Config.m_ClDummyControl)
 		{
-			int DummyControlReleaseFlags = 0;
-			if(g_Config.m_ClDummyLeft || g_Config.m_ClDummyRight)
-			{
-				pDummyInput->m_Direction = g_Config.m_ClDummyRight - g_Config.m_ClDummyLeft;
-				DummyControlReleaseFlags |= CGameClient::DUMMY_CONTROL_RELEASE_DIRECTION;
-			}
-			else if(!g_Config.m_ClDummyCopyMoves)
-				pDummyInput->m_Direction = m_aInputData[!g_Config.m_ClDummy].m_Direction;
+			pDummyInput->m_Direction = 0;
+			if(g_Config.m_ClDummyLeft && !g_Config.m_ClDummyRight)
+				pDummyInput->m_Direction = -1;
+			if(!g_Config.m_ClDummyLeft && g_Config.m_ClDummyRight)
+				pDummyInput->m_Direction = 1;
 
 			pDummyInput->m_Jump = g_Config.m_ClDummyJump;
-			if(g_Config.m_ClDummyJump)
-				DummyControlReleaseFlags |= CGameClient::DUMMY_CONTROL_RELEASE_JUMP;
 
 			if(g_Config.m_ClDummyFire)
-			{
 				pDummyInput->m_Fire = g_Config.m_ClDummyFire;
-				DummyControlReleaseFlags |= CGameClient::DUMMY_CONTROL_RELEASE_FIRE;
-			}
 			else if((pDummyInput->m_Fire & 1) != 0)
 				pDummyInput->m_Fire++;
 
 			pDummyInput->m_Hook = g_Config.m_ClDummyHook;
-			if(g_Config.m_ClDummyHook)
-				DummyControlReleaseFlags |= CGameClient::DUMMY_CONTROL_RELEASE_HOOK;
-
-			GameClient()->m_DummyControlReleaseFlags = DummyControlReleaseFlags;
-		}
-		else if(GameClient()->m_DummyControlReleaseFlags != 0)
-		{
-			int RemainingReleaseFlags = 0;
-			if(!g_Config.m_ClDummyCopyMoves)
-			{
-				if(GameClient()->m_DummyControlReleaseFlags & CGameClient::DUMMY_CONTROL_RELEASE_DIRECTION)
-					pDummyInput->m_Direction = 0;
-				if(GameClient()->m_DummyControlReleaseFlags & CGameClient::DUMMY_CONTROL_RELEASE_JUMP)
-					pDummyInput->m_Jump = 0;
-			}
-			if(GameClient()->m_DummyControlReleaseFlags & CGameClient::DUMMY_CONTROL_RELEASE_FIRE)
-			{
-				if((pDummyInput->m_Fire & 1) != 0)
-					pDummyInput->m_Fire++;
-			}
-			if(GameClient()->m_DummyControlReleaseFlags & CGameClient::DUMMY_CONTROL_RELEASE_HOOK)
-			{
-				// Keep dummy hook pressed after leaving dummy-control mode until the dedicated
-				// hook bind is actually released, otherwise toggling control off drops the hook.
-				if(g_Config.m_ClDummyHook)
-				{
-					pDummyInput->m_Hook = 1;
-					RemainingReleaseFlags |= CGameClient::DUMMY_CONTROL_RELEASE_HOOK;
-				}
-				else if(!g_Config.m_ClDummyCopyMoves)
-				{
-					pDummyInput->m_Hook = 0;
-				}
-			}
-
-			GameClient()->m_DummyControlReleaseFlags = RemainingReleaseFlags;
+			m_aInputData[!g_Config.m_ClDummy] = *pDummyInput;
 		}
 
 		// stress testing

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -922,37 +922,36 @@ void CHud::RenderGameTimer()
 
 void CHud::RenderPauseNotification()
 {
-	const bool Preview = GameClient()->m_HudEditor.IsActive() &&
-		((GameClient()->m_Snap.m_pGameInfoObj->m_GameStateFlags & GAMESTATEFLAG_PAUSED) == 0 ||
-		 (GameClient()->m_Snap.m_pGameInfoObj->m_GameStateFlags & GAMESTATEFLAG_GAMEOVER) != 0);
-	if((GameClient()->m_Snap.m_pGameInfoObj->m_GameStateFlags & GAMESTATEFLAG_PAUSED &&
-		!(GameClient()->m_Snap.m_pGameInfoObj->m_GameStateFlags & GAMESTATEFLAG_GAMEOVER)) || Preview)
-	{
-		const char *pText = Localize("Game paused");
-		float FontSize = 20.0f;
-		float w = TextRender()->TextWidth(FontSize, pText, -1, -1.0f);
-		const float X = 150.0f * Graphics()->ScreenAspect() - w / 2.0f;
-		const float Y = 50.0f;
-		const auto HudEditorScope = GameClient()->m_HudEditor.BeginTransform(EHudEditorElement::PauseNotification, {X, Y, w, FontSize + 4.0f});
-		TextRender()->Text(X, Y, FontSize, pText, -1.0f);
-		GameClient()->m_HudEditor.EndTransform(HudEditorScope);
-	}
+	const bool Paused = (GameClient()->m_Snap.m_pGameInfoObj->m_GameStateFlags & GAMESTATEFLAG_PAUSED) != 0;
+	const bool GameOver = (GameClient()->m_Snap.m_pGameInfoObj->m_GameStateFlags & GAMESTATEFLAG_GAMEOVER) != 0;
+	if(!Paused || GameOver)
+		return;
+
+	const char *pText = Localize("Game paused");
+	float FontSize = 20.0f;
+	float w = TextRender()->TextWidth(FontSize, pText, -1, -1.0f);
+	const float X = 150.0f * Graphics()->ScreenAspect() - w / 2.0f;
+	const float Y = 50.0f;
+	const auto HudEditorScope = GameClient()->m_HudEditor.BeginTransform(EHudEditorElement::PauseNotification, {X, Y, w, FontSize + 4.0f});
+	TextRender()->Text(X, Y, FontSize, pText, -1.0f);
+	GameClient()->m_HudEditor.EndTransform(HudEditorScope);
 }
 
 void CHud::RenderSuddenDeath()
 {
-	if((GameClient()->m_Snap.m_pGameInfoObj->m_GameStateFlags & GAMESTATEFLAG_SUDDENDEATH) || GameClient()->m_HudEditor.IsActive())
-	{
-		float Half = m_Width / 2.0f;
-		const char *pText = Localize("Sudden Death");
-		float FontSize = 12.0f;
-		float w = TextRender()->TextWidth(FontSize, pText, -1, -1.0f);
-		const float X = Half - w / 2.0f;
-		const float Y = 2.0f;
-		const auto HudEditorScope = GameClient()->m_HudEditor.BeginTransform(EHudEditorElement::SuddenDeath, {X, Y, w, FontSize + 4.0f});
-		TextRender()->Text(X, Y, FontSize, pText, -1.0f);
-		GameClient()->m_HudEditor.EndTransform(HudEditorScope);
-	}
+	const bool SuddenDeath = (GameClient()->m_Snap.m_pGameInfoObj->m_GameStateFlags & GAMESTATEFLAG_SUDDENDEATH) != 0;
+	if(!SuddenDeath)
+		return;
+
+	float Half = m_Width / 2.0f;
+	const char *pText = Localize("Sudden Death");
+	float FontSize = 12.0f;
+	float w = TextRender()->TextWidth(FontSize, pText, -1, -1.0f);
+	const float X = Half - w / 2.0f;
+	const float Y = 2.0f;
+	const auto HudEditorScope = GameClient()->m_HudEditor.BeginTransform(EHudEditorElement::SuddenDeath, {X, Y, w, FontSize + 4.0f});
+	TextRender()->Text(X, Y, FontSize, pText, -1.0f);
+	GameClient()->m_HudEditor.EndTransform(HudEditorScope);
 }
 
 void CHud::RenderScoreHud()
@@ -1280,28 +1279,29 @@ void CHud::RenderScoreHud()
 void CHud::RenderWarmupTimer()
 {
 	// render warmup timer
-	const bool Preview = GameClient()->m_HudEditor.IsActive() &&
-		(GameClient()->m_Snap.m_pGameInfoObj->m_WarmupTimer <= 0 || (GameClient()->m_Snap.m_pGameInfoObj->m_GameStateFlags & GAMESTATEFLAG_RACETIME) != 0);
-	if((GameClient()->m_Snap.m_pGameInfoObj->m_WarmupTimer > 0 && !(GameClient()->m_Snap.m_pGameInfoObj->m_GameStateFlags & GAMESTATEFLAG_RACETIME)) || Preview)
-	{
-		char aBuf[256];
-		float FontSize = 20.0f;
-		float w = TextRender()->TextWidth(FontSize, Localize("Warmup"), -1, -1.0f);
+	const bool RaceTime = (GameClient()->m_Snap.m_pGameInfoObj->m_GameStateFlags & GAMESTATEFLAG_RACETIME) != 0;
+	if(GameClient()->m_Snap.m_pGameInfoObj->m_WarmupTimer <= 0 || RaceTime)
+		return;
 
-		int Seconds = Preview ? 8 : GameClient()->m_Snap.m_pGameInfoObj->m_WarmupTimer / Client()->GameTickSpeed();
-		if(Seconds < 5)
-			str_format(aBuf, sizeof(aBuf), "%d.%d", Seconds, (GameClient()->m_Snap.m_pGameInfoObj->m_WarmupTimer * 10 / Client()->GameTickSpeed()) % 10);
-		else
-			str_format(aBuf, sizeof(aBuf), "%d", Seconds);
-		const float LabelWidth = w;
-		w = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f);
-		const float MaxWidth = maximum(LabelWidth, w);
-		const float BaseX = 150.0f * Graphics()->ScreenAspect() - MaxWidth / 2.0f;
-		const auto HudEditorScope = GameClient()->m_HudEditor.BeginTransform(EHudEditorElement::WarmupTimer, {BaseX, 50.0f, MaxWidth, 45.0f});
-		TextRender()->Text(150 * Graphics()->ScreenAspect() + -LabelWidth / 2, 50, FontSize, Localize("Warmup"), -1.0f);
-		TextRender()->Text(150 * Graphics()->ScreenAspect() + -w / 2, 75, FontSize, aBuf, -1.0f);
-		GameClient()->m_HudEditor.EndTransform(HudEditorScope);
-	}
+	char aBuf[256];
+	float FontSize = 20.0f;
+	float w = TextRender()->TextWidth(FontSize, Localize("Warmup"), -1, -1.0f);
+	const int Seconds = GameClient()->m_Snap.m_pGameInfoObj->m_WarmupTimer / Client()->GameTickSpeed();
+	if(Seconds < 5)
+		str_format(aBuf, sizeof(aBuf), "%d.%d", Seconds, (GameClient()->m_Snap.m_pGameInfoObj->m_WarmupTimer * 10 / Client()->GameTickSpeed()) % 10);
+	else
+		str_format(aBuf, sizeof(aBuf), "%d", Seconds);
+	const float LabelWidth = w;
+	w = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f);
+	const float MaxWidth = maximum(LabelWidth, w);
+	const float BaseX = 150.0f * Graphics()->ScreenAspect() - MaxWidth / 2.0f;
+	const float BaseY = 50.0f;
+	const auto HudEditorScope = GameClient()->m_HudEditor.BeginTransform(EHudEditorElement::WarmupTimer, {BaseX, BaseY, MaxWidth, 45.0f});
+
+	TextRender()->Text(150 * Graphics()->ScreenAspect() + -LabelWidth / 2, BaseY, FontSize, Localize("Warmup"), -1.0f);
+	TextRender()->Text(150 * Graphics()->ScreenAspect() + -w / 2, BaseY + 25.0f, FontSize, aBuf, -1.0f);
+
+	GameClient()->m_HudEditor.EndTransform(HudEditorScope);
 }
 
 namespace

--- a/src/game/client/components/hud_editor.cpp
+++ b/src/game/client/components/hud_editor.cpp
@@ -495,6 +495,9 @@ void CHudEditor::OnRender()
 	{
 		const bool Hovered = static_cast<int>(i) == HoveredIndex;
 		const bool Dragging = m_DraggingElement >= 0 && static_cast<int>(m_vVisibleElements[i].m_Element) == m_DraggingElement;
+		if(!Hovered && !Dragging)
+			continue;
+
 		const ColorRGBA FillColor = Dragging ? ColorRGBA(1.0f, 0.75f, 0.15f, 0.10f) : (Hovered ? ColorRGBA(0.35f, 0.75f, 1.0f, 0.10f) : ColorRGBA(1.0f, 1.0f, 1.0f, 0.04f));
 		const ColorRGBA BorderColor = Dragging ? ColorRGBA(1.0f, 0.82f, 0.20f, 0.95f) : (Hovered ? ColorRGBA(0.35f, 0.80f, 1.0f, 0.90f) : ColorRGBA(1.0f, 1.0f, 1.0f, 0.55f));
 		const float BorderSize = Dragging ? 2.5f : 1.5f;

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -737,6 +737,7 @@ protected:
 	void RenderServerbrowserInfo(CUIRect View);
 	void RenderServerbrowserInfoScoreboard(CUIRect View, const CServerInfo *pSelectedServer);
 	void RenderServerbrowserFriends(CUIRect View);
+	void RenderServerbrowserQm(CUIRect View);
 	static CUi::EPopupMenuFunctionResult PopupFriendsCategory(void *pContext, CUIRect View, bool Active);
 	static CUi::EPopupMenuFunctionResult PopupFriendNote(void *pContext, CUIRect View, bool Active);
 	void FriendlistOnUpdate();
@@ -925,6 +926,7 @@ public:
 		SMALL_TAB_BROWSER_FILTER,
 		SMALL_TAB_BROWSER_INFO,
 		SMALL_TAB_BROWSER_FRIENDS,
+		SMALL_TAB_BROWSER_QM,
 
 		SMALL_TAB_LENGTH,
 	};

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -27,6 +27,42 @@ using namespace FontIcons;
 
 static constexpr ColorRGBA gs_HighlightedTextColor = ColorRGBA(0.4f, 0.4f, 1.0f, 1.0f);
 
+static const CServerInfo *FindSortedServerByAddress(IServerBrowser *pServerBrowser, const char *pAddress, int *pIndex = nullptr)
+{
+	if(pIndex != nullptr)
+		*pIndex = -1;
+	if(pServerBrowser == nullptr || pAddress == nullptr || pAddress[0] == '\0')
+		return nullptr;
+
+	for(int i = 0; i < pServerBrowser->NumSortedServers(); ++i)
+	{
+		const CServerInfo *pServerInfo = pServerBrowser->SortedGet(i);
+		if(pServerInfo != nullptr && str_comp(pServerInfo->m_aAddress, pAddress) == 0)
+		{
+			if(pIndex != nullptr)
+				*pIndex = i;
+			return pServerInfo;
+		}
+	}
+
+	return nullptr;
+}
+
+static const CServerInfo *FindServerByAddress(IServerBrowser *pServerBrowser, const char *pAddress)
+{
+	if(pServerBrowser == nullptr || pAddress == nullptr || pAddress[0] == '\0')
+		return nullptr;
+
+	for(int i = 0; i < pServerBrowser->NumServers(); ++i)
+	{
+		const CServerInfo *pServerInfo = pServerBrowser->Get(i);
+		if(pServerInfo != nullptr && str_comp(pServerInfo->m_aAddress, pAddress) == 0)
+			return pServerInfo;
+	}
+
+	return nullptr;
+}
+
 static bool IsClanMembersCategory(const char *pCategory)
 {
 	return pCategory != nullptr && str_comp_nocase(pCategory, IFriends::CLAN_MEMBERS_CATEGORY) == 0;
@@ -2642,19 +2678,141 @@ void CMenus::PopupCancelRemoveFriend()
 	m_RemoveFriendState = IFriends::FRIEND_NO;
 }
 
+void CMenus::RenderServerbrowserQm(CUIRect View)
+{
+	const float RowHeight = 18.0f;
+	const float FontSize = (RowHeight - 4.0f) * CUi::ms_FontmodHeight;
+	const auto &vQmServers = GameClient()->m_TClient.QmClientServerDistribution();
+	const int QmUsers = GameClient()->m_TClient.QmClientOnlineUserCount();
+	const int QmDummies = GameClient()->m_TClient.QmClientOnlineDummyCount();
+
+	View.Margin(5.0f, &View);
+
+	CUIRect Header, Summary, List, Row;
+	View.HSplitTop(15.0f, &Header, &View);
+	Ui()->DoLabel(&Header, Localize("QmClient online distribution"), FontSize, TEXTALIGN_ML);
+	View.HSplitTop(5.0f, nullptr, &View);
+	View.HSplitTop(28.0f, &Summary, &View);
+
+	if(g_Config.m_RiVoiceServer[0] == '\0')
+	{
+		Ui()->DoLabel(&Summary, Localize("Set a voice server to enable QmClient distribution"), 9.0f, TEXTALIGN_ML);
+		return;
+	}
+
+	char aSummary[128];
+	if(QmDummies > 0)
+		str_format(aSummary, sizeof(aSummary), Localize("%d servers, %d users, %d dummies"), (int)vQmServers.size(), QmUsers, QmDummies);
+	else
+		str_format(aSummary, sizeof(aSummary), Localize("%d servers, %d users"), (int)vQmServers.size(), QmUsers);
+	Ui()->DoLabel(&Summary, aSummary, 9.0f, TEXTALIGN_ML);
+
+	if(vQmServers.empty())
+	{
+		View.HSplitTop(2.0f, nullptr, &View);
+		View.HSplitTop(RowHeight, &Row, &View);
+		Ui()->DoLabel(&Row, Localize("No active QmClient reports yet"), FontSize, TEXTALIGN_ML);
+		return;
+	}
+
+	View.HSplitTop(2.0f, nullptr, &View);
+	List = View;
+
+	int SelectedQmIndex = -1;
+	for(size_t i = 0; i < vQmServers.size(); ++i)
+	{
+		if(str_comp(vQmServers[i].m_ServerAddress.c_str(), g_Config.m_UiServerAddress) == 0)
+		{
+			SelectedQmIndex = (int)i;
+			break;
+		}
+	}
+
+	static CListBox s_QmServerListBox;
+	static std::vector<int> s_vQmServerItemIds;
+	s_vQmServerItemIds.resize(vQmServers.size());
+	s_QmServerListBox.DoAutoSpacing(2.0f);
+	s_QmServerListBox.SetScrollbarWidth(16.0f);
+	s_QmServerListBox.SetScrollbarMargin(5.0f);
+	s_QmServerListBox.DoStart(40.0f, vQmServers.size(), 1, 3, SelectedQmIndex, &List, false, IGraphics::CORNER_NONE, true);
+
+	for(size_t i = 0; i < vQmServers.size(); ++i)
+	{
+		const SQmClientServerDistribution &Entry = vQmServers[i];
+		int SortedServerIndex = -1;
+		const CServerInfo *pSortedServer = FindSortedServerByAddress(ServerBrowser(), Entry.m_ServerAddress.c_str(), &SortedServerIndex);
+		const CServerInfo *pKnownServer = pSortedServer != nullptr ? pSortedServer : FindServerByAddress(ServerBrowser(), Entry.m_ServerAddress.c_str());
+
+		const CListboxItem Item = s_QmServerListBox.DoNextItem(&s_vQmServerItemIds[i], SelectedQmIndex == (int)i);
+		if(!Item.m_Visible)
+			continue;
+
+		CUIRect ItemRect, TextRect, CountRect, TitleRect, DetailRect, UsersRect, DummiesRect;
+		Item.m_Rect.Margin(4.0f, &ItemRect);
+		if(Item.m_Selected)
+			ItemRect.Draw(ColorRGBA(0.23f, 0.51f, 0.82f, 0.12f), IGraphics::CORNER_ALL, 6.0f);
+
+		ItemRect.VSplitRight(100.0f, &TextRect, &CountRect);
+		TextRect.HSplitTop(18.0f, &TitleRect, &DetailRect);
+		CountRect.HSplitTop(18.0f, &UsersRect, &DummiesRect);
+
+		const char *pTitle = pKnownServer != nullptr && pKnownServer->m_aName[0] != '\0' ? pKnownServer->m_aName : Entry.m_ServerAddress.c_str();
+		Ui()->DoLabel(&TitleRect, pTitle, FontSize, TEXTALIGN_ML);
+
+		char aDetail[128];
+		if(pSortedServer != nullptr && Item.m_Selected)
+			str_format(aDetail, sizeof(aDetail), "%s | %s", Localize("Selected server"), pSortedServer->m_aAddress);
+		else if(pSortedServer != nullptr)
+			str_copy(aDetail, pSortedServer->m_aAddress, sizeof(aDetail));
+		else if(pKnownServer != nullptr)
+			str_format(aDetail, sizeof(aDetail), "%s | %s", Localize("Not in the current browser list"), pKnownServer->m_aAddress);
+		else
+			str_copy(aDetail, Localize("Not in the current browser list"), sizeof(aDetail));
+		Ui()->DoLabel(&DetailRect, aDetail, 8.0f, TEXTALIGN_ML);
+
+		char aUsers[48];
+		str_format(aUsers, sizeof(aUsers), Localize(Entry.m_UserCount == 1 ? "%d user" : "%d users"), Entry.m_UserCount);
+		Ui()->DoLabel(&UsersRect, aUsers, 9.0f, TEXTALIGN_MR);
+
+		if(Entry.m_DummyCount > 0)
+		{
+			char aDummies[48];
+			str_format(aDummies, sizeof(aDummies), Localize(Entry.m_DummyCount == 1 ? "%d dummy" : "%d dummies"), Entry.m_DummyCount);
+			Ui()->DoLabel(&DummiesRect, aDummies, 8.0f, TEXTALIGN_MR);
+		}
+	}
+
+	const int NewSelected = s_QmServerListBox.DoEnd();
+	if((s_QmServerListBox.WasItemSelected() || s_QmServerListBox.WasItemActivated()) &&
+		NewSelected >= 0 &&
+		NewSelected < (int)vQmServers.size())
+	{
+		int SortedServerIndex = -1;
+		const CServerInfo *pServerInfo = FindSortedServerByAddress(ServerBrowser(), vQmServers[NewSelected].m_ServerAddress.c_str(), &SortedServerIndex);
+		if(pServerInfo != nullptr && SortedServerIndex >= 0)
+		{
+			m_SelectedIndex = SortedServerIndex;
+			str_copy(g_Config.m_UiServerAddress, pServerInfo->m_aAddress);
+			m_ServerBrowserShouldRevealSelection = true;
+		}
+	}
+}
+
 enum
 {
 	UI_TOOLBOX_PAGE_FILTERS = 0,
 	UI_TOOLBOX_PAGE_INFO,
 	UI_TOOLBOX_PAGE_FRIENDS,
+	UI_TOOLBOX_PAGE_QM,
 	NUM_UI_TOOLBOX_PAGES,
 };
 
 void CMenus::RenderServerbrowserTabBar(CUIRect TabBar)
 {
-	CUIRect FilterTabButton, InfoTabButton, FriendsTabButton;
-	TabBar.VSplitLeft(TabBar.w / 3.0f, &FilterTabButton, &TabBar);
-	TabBar.VSplitMid(&InfoTabButton, &FriendsTabButton);
+	CUIRect FilterTabButton, InfoTabButton, FriendsTabButton, QmTabButton;
+	TabBar.VSplitLeft(TabBar.w / 4.0f, &FilterTabButton, &TabBar);
+	TabBar.VSplitLeft(TabBar.w / 3.0f, &InfoTabButton, &TabBar);
+	TabBar.VSplitLeft(TabBar.w / 2.0f, &FriendsTabButton, &QmTabButton);
 
 	const ColorRGBA ColorActive = ColorRGBA(0.0f, 0.0f, 0.0f, 0.3f);
 	const ColorRGBA ColorInactive = ColorRGBA(0.0f, 0.0f, 0.0f, 0.15f);
@@ -2688,6 +2846,15 @@ void CMenus::RenderServerbrowserTabBar(CUIRect TabBar)
 		g_Config.m_UiToolboxPage = UI_TOOLBOX_PAGE_FRIENDS;
 	}
 	GameClient()->m_Tooltips.DoToolTip(&s_FriendsTabButton, &FriendsTabButton, Localize("Friends"));
+
+	TextRender()->SetRenderFlags(0);
+	TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
+	static CButtonContainer s_QmTabButton;
+	if(DoButton_MenuTab(&s_QmTabButton, "Qm", g_Config.m_UiToolboxPage == UI_TOOLBOX_PAGE_QM, &QmTabButton, IGraphics::CORNER_T, &m_aAnimatorsSmallPage[SMALL_TAB_BROWSER_QM], &ColorInactive, &ColorActive))
+	{
+		g_Config.m_UiToolboxPage = UI_TOOLBOX_PAGE_QM;
+	}
+	GameClient()->m_Tooltips.DoToolTip(&s_QmTabButton, &QmTabButton, Localize("QmClient"));
 
 	TextRender()->SetRenderFlags(0);
 	TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
@@ -2725,6 +2892,9 @@ void CMenus::RenderServerbrowserToolBox(CUIRect ToolBox)
 		break;
 	case UI_TOOLBOX_PAGE_FRIENDS:
 		RenderServerbrowserFriends(ToolBox);
+		break;
+	case UI_TOOLBOX_PAGE_QM:
+		RenderServerbrowserQm(ToolBox);
 		break;
 	default:
 		dbg_assert_failed("ui_toolbox_page invalid");

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -832,8 +832,7 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 	QueuePanel.VSplitLeft(10.0f, nullptr, &QueuePanel);
 
 	{
-		const int UnfilteredCount = SkinList.UnfilteredCount();
-		const int QueueMaxLimit = UnfilteredCount > 0 ? UnfilteredCount : QueueLength;
+		const int QueueMaxLimit = 1024;
 		const int PrevQueueLength = QueueLength;
 		if(QueueMaxLimit >= 0)
 		{
@@ -944,13 +943,15 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 				TeeRect.VSplitLeft(3.0f, nullptr, &TeeRect);
 
 				char aEntryLabel[64];
-				str_format(aEntryLabel, sizeof(aEntryLabel), "%d. %s", (int)i + 1, SkinQueue[i].c_str());
+				str_format(aEntryLabel, sizeof(aEntryLabel), "%d. %s", (int)i + 1, SkinQueue[i].m_SkinName.c_str());
 				LabelRect.VSplitLeft(4.0f, nullptr, &LabelRect);
 				Ui()->DoLabel(&LabelRect, aEntryLabel, 12.0f, TEXTALIGN_ML);
 
-				const CSkin *pQueueSkin = GameClient()->m_Skins.Find(SkinQueue[i].c_str());
+				const CSkins::CSkinQueueEntry &QueueEntry = SkinQueue[i];
+				const CSkin *pQueueSkin = GameClient()->m_Skins.Find(QueueEntry.m_SkinName.c_str());
 				CTeeRenderInfo QueueInfo = OwnSkinInfo;
 				QueueInfo.Apply(pQueueSkin);
+				QueueInfo.ApplyColors(QueueEntry.m_UseCustomColor, QueueEntry.m_ColorBody, QueueEntry.m_ColorFeet);
 				QueueInfo.m_Size = TeeSize;
 				vec2 OffsetToMid;
 				CRenderTools::GetRenderTeeOffsetToRenderedTee(CAnimState::GetIdle(), &QueueInfo, OffsetToMid);
@@ -1004,7 +1005,7 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 
 			if(RemoveIndex >= 0 && RemoveIndex < (int)SkinQueue.size())
 			{
-				GameClient()->m_Skins.RemoveSkinQueue(SkinQueue[RemoveIndex].c_str(), QueueDummy);
+				GameClient()->m_Skins.RemoveSkinQueue(SkinQueue[RemoveIndex], QueueDummy);
 				s_QueueDragIndex = -1;
 				s_QueueDragging = false;
 			}
@@ -1227,17 +1228,17 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 			IconRow.VSplitRight(20.0f, &IconRow, &FavIcon);
 			IconRow.VSplitRight(2.0f, &IconRow, nullptr);
 			IconRow.VSplitRight(20.0f, &IconRow, &QueueIcon);
-			const bool InQueue = GameClient()->m_Skins.IsInSkinQueue(pSkinContainer->Name(), QueueDummy);
+			const bool InQueue = GameClient()->m_Skins.IsInSkinQueue(pSkinContainer->Name(), *pUseCustomColor != 0, *pColorBody, *pColorFeet, QueueDummy);
 			const bool QueueFull = !InQueue && (int)SkinQueue.size() >= QueueLength;
 			if(DoButton_SkinQueue(&s_vQueueButtonIds[i], SkinListEntry.ListItemId(), InQueue, QueueFull, &QueueIcon))
 			{
 				if(InQueue)
 				{
-					GameClient()->m_Skins.RemoveSkinQueue(pSkinContainer->Name(), QueueDummy);
+					GameClient()->m_Skins.RemoveSkinQueue(pSkinContainer->Name(), *pUseCustomColor != 0, *pColorBody, *pColorFeet, QueueDummy);
 				}
 				else
 				{
-					GameClient()->m_Skins.AddSkinQueue(pSkinContainer->Name(), QueueDummy);
+					GameClient()->m_Skins.AddSkinQueue(pSkinContainer->Name(), *pUseCustomColor != 0, *pColorBody, *pColorFeet, QueueDummy);
 				}
 			}
 			const char *pQueueTooltip = QueueFull && !InQueue ? Localize("队列已满") : (InQueue ? Localize("从队列移除") : Localize("加入队列"));

--- a/src/game/client/components/qmclient/menus_qmclient.cpp
+++ b/src/game/client/components/qmclient/menus_qmclient.cpp
@@ -911,7 +911,7 @@ void CMenus::RenderSettingsTClientSettings(CUIRect MainView)
 	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_TcFastInput, Localize("Fast input (reduce visual latency)"), &g_Config.m_TcFastInput, &Column, LineSize);
 
 	Column.HSplitTop(LineSize, &Button, &Column);
-	DoSliderWithScaledValue(&g_Config.m_TcFastInputAmount, &g_Config.m_TcFastInputAmount, &Button, Localize("Amount"), 1, 100, 1, &CUi::ms_LinearScrollbarScale, CUi::SCROLLBAR_OPTION_NOCLAMPVALUE, "ms");
+	DoSliderWithScaledValue(&g_Config.m_TcFastInputAmount, &g_Config.m_TcFastInputAmount, &Button, Localize("Amount"), 1, 40, 1, &CUi::ms_LinearScrollbarScale, CUi::SCROLLBAR_OPTION_NOCLAMPVALUE, "ms");
 
 	Column.HSplitTop(MarginSmall, nullptr, &Column);
 	if(g_Config.m_TcFastInput)
@@ -4971,7 +4971,7 @@ void CMenus::RenderSettingsQiMeng(CUIRect MainView)
 
 			RightContent.HSplitTop(LG_LineSpacing * 0.55f, nullptr, &RightContent);
 			RightContent.HSplitTop(LG_LineHeight * 0.9f, &Row, &RightContent);
-			Ui()->DoLabel(&Row, Localize("I could not have come this far without your support, big or small. Thank you."), LG_BodySize * 0.93f, TEXTALIGN_ML);
+			Ui()->DoLabel(&Row, Localize("感谢你们一直以来的陪伴与坚信让我能够有勇气走下去,谢谢"), LG_BodySize * 0.93f, TEXTALIGN_ML);
 			TextRender()->TextColor(TextRender()->DefaultTextColor());
 
 			const float RightUsedHeight = RightContent.y - RightStartY;

--- a/src/game/client/components/qmclient/qmclient.cpp
+++ b/src/game/client/components/qmclient/qmclient.cpp
@@ -115,6 +115,45 @@ static constexpr const char *s_pFriendEnterBroadcastDefaultText = "%s joined thi
 static int AutoReplySeparatorLength(const char *pStr);
 static void AppendAutoReplyRuleBlock(char *pOutRules, size_t OutRulesSize, const char *pRules);
 
+namespace
+{
+enum class EFreezeWakeupType
+{
+	NONE,
+	LOCAL_HAMMER,
+	EXTERNAL_HAMMER,
+};
+
+EFreezeWakeupType DetectFreezeWakeupType(CGameClient *pGameClient, int ClientId)
+{
+	const CCharacter *pPredictedChar = pGameClient->m_PredictedWorld.GetCharacterById(ClientId);
+	if(pPredictedChar == nullptr)
+		return EFreezeWakeupType::NONE;
+
+	const int LastDamageTick = pPredictedChar->GetLastDamageTick();
+	const int DamageTickDelta = pGameClient->m_PredictedWorld.GameTick() - LastDamageTick;
+	const int DamageTickWindow = maximum(2, pGameClient->m_PredictedWorld.GameTickSpeed() / 6);
+	const int DamageFrom = pPredictedChar->GetLastDamageFrom();
+	if(LastDamageTick <= 0 ||
+		DamageTickDelta < 0 ||
+		DamageTickDelta > DamageTickWindow ||
+		pPredictedChar->GetLastDamageWeapon() != WEAPON_HAMMER ||
+		DamageFrom < 0)
+	{
+		return EFreezeWakeupType::NONE;
+	}
+
+	if(DamageFrom == ClientId ||
+		DamageFrom == pGameClient->m_aLocalIds[0] ||
+		DamageFrom == pGameClient->m_aLocalIds[1])
+	{
+		return EFreezeWakeupType::LOCAL_HAMMER;
+	}
+
+	return EFreezeWakeupType::EXTERNAL_HAMMER;
+}
+}
+
 struct SKeywordReplyRule
 {
 	std::string m_Keywords;
@@ -2477,6 +2516,7 @@ void CTClient::ResetQmClientRecognitionTasks()
 	AbortTask(m_pQmClientUsersSendTask);
 	m_aQmClientAuthToken[0] = '\0';
 	m_QmClientLastSync = 0;
+	ClearQmClientServerDistribution();
 }
 
 bool CTClient::BuildQmClientRecognitionUrl(const char *pPath, char *pBuf, size_t BufSize, const char *pQuery) const
@@ -2508,6 +2548,13 @@ bool CTClient::BuildQmClientRecognitionUrl(const char *pPath, char *pBuf, size_t
 	}
 
 	return pBuf[0] != '\0';
+}
+
+void CTClient::ClearQmClientServerDistribution()
+{
+	m_vQmClientServerDistribution.clear();
+	m_QmClientOnlineUserCount = 0;
+	m_QmClientOnlineDummyCount = 0;
 }
 
 bool CTClient::EnsureQmClientMachineHash()
@@ -2599,8 +2646,9 @@ void CTClient::SendQmClientPlayerData()
 	if(!EnsureQmClientMachineHash())
 		return;
 
-	char aServerAddress[NETADDR_MAXSTRSIZE];
-	net_addr_str(&Client()->ServerAddress(), aServerAddress, sizeof(aServerAddress), true);
+	char aServerAddress[NETADDR_MAXSTRSIZE] = "";
+	if(Client()->State() == IClient::STATE_ONLINE)
+		net_addr_str(&Client()->ServerAddress(), aServerAddress, sizeof(aServerAddress), true);
 	if(aServerAddress[0] == '\0')
 		return;
 
@@ -2702,6 +2750,7 @@ void CTClient::FinishQmClientUsers()
 
 	GameClient()->ClearQ1menGSyncMarks();
 	GameClient()->ClearQmVoiceSyncMarks();
+	ClearQmClientServerDistribution();
 
 	if(m_pQmClientUsersTask->State() != EHttpState::DONE)
 		return;
@@ -2724,11 +2773,13 @@ void CTClient::FinishQmClientUsers()
 		return;
 	}
 
-	char aServerAddress[NETADDR_MAXSTRSIZE];
-	net_addr_str(&Client()->ServerAddress(), aServerAddress, sizeof(aServerAddress), true);
+	char aServerAddress[NETADDR_MAXSTRSIZE] = "";
+	if(Client()->State() == IClient::STATE_ONLINE)
+		net_addr_str(&Client()->ServerAddress(), aServerAddress, sizeof(aServerAddress), true);
 	const bool FastSync = g_Config.m_RiVoiceEnable || g_Config.m_QmClientShowBadge;
 	const int SyncInterval = FastSync ? QMCLIENT_VOICE_SYNC_INTERVAL_SECONDS : QMCLIENT_SYNC_INTERVAL_SECONDS;
 	const int64_t ExpireTick = time_get() + (int64_t)SyncInterval * time_freq() * 2;
+	std::unordered_map<std::string, size_t> ServerIndexByAddress;
 
 	for(unsigned Index = 0; Index < pUsers->u.array.length; ++Index)
 	{
@@ -2741,8 +2792,6 @@ void CTClient::FinishQmClientUsers()
 			pServerAddress = JsonObjectField(pEntry, "server");
 		if(pServerAddress == &json_value_none || pServerAddress->type != json_string)
 			continue;
-		if(str_comp(pServerAddress->u.string.ptr, aServerAddress) != 0)
-			continue;
 
 		const json_value *pPlayerId = JsonObjectField(pEntry, "player_id");
 		if(pPlayerId == &json_value_none)
@@ -2751,6 +2800,33 @@ void CTClient::FinishQmClientUsers()
 			continue;
 
 		const int ClientId = json_int_get(pPlayerId);
+		bool Dummy = false;
+		const json_value *pDummy = JsonObjectField(pEntry, "dummy");
+		if(pDummy != &json_value_none)
+			JsonReadBoolean(pDummy, Dummy);
+
+		const std::string ServerAddress = pServerAddress->u.string.ptr;
+		const auto ItServer = ServerIndexByAddress.find(ServerAddress);
+		if(ItServer == ServerIndexByAddress.end())
+		{
+			ServerIndexByAddress[ServerAddress] = m_vQmClientServerDistribution.size();
+			m_vQmClientServerDistribution.push_back({ServerAddress, 0, 0});
+		}
+		SQmClientServerDistribution &ServerDistribution = m_vQmClientServerDistribution[ServerIndexByAddress[ServerAddress]];
+		if(Dummy)
+		{
+			++ServerDistribution.m_DummyCount;
+			++m_QmClientOnlineDummyCount;
+		}
+		else
+		{
+			++ServerDistribution.m_UserCount;
+			++m_QmClientOnlineUserCount;
+		}
+
+		if(str_comp(pServerAddress->u.string.ptr, aServerAddress) != 0)
+			continue;
+
 		const char *pQid = "";
 		const json_value *pQidField = JsonObjectField(pEntry, "qid");
 		if(pQidField != &json_value_none && pQidField->type == json_string)
@@ -2773,12 +2849,22 @@ void CTClient::FinishQmClientUsers()
 			GameClient()->MarkQmVoiceSupportedClient(ClientId, ExpireTick);
 	}
 
+	std::sort(m_vQmClientServerDistribution.begin(), m_vQmClientServerDistribution.end(), [](const SQmClientServerDistribution &Left, const SQmClientServerDistribution &Right) {
+		if(Left.m_UserCount != Right.m_UserCount)
+			return Left.m_UserCount > Right.m_UserCount;
+		if(Left.m_DummyCount != Right.m_DummyCount)
+			return Left.m_DummyCount > Right.m_DummyCount;
+		return str_comp(Left.m_ServerAddress.c_str(), Right.m_ServerAddress.c_str()) < 0;
+	});
+
 	json_value_free(pRoot);
 }
 
 void CTClient::SyncQmClientUsers()
 {
-	if((m_pQmClientUsersTask && !m_pQmClientUsersTask->Done()) || (m_pQmClientUsersSendTask && !m_pQmClientUsersSendTask->Done()))
+	if(m_pQmClientUsersTask && !m_pQmClientUsersTask->Done())
+		return;
+	if(Client()->State() == IClient::STATE_ONLINE && m_pQmClientUsersSendTask && !m_pQmClientUsersSendTask->Done())
 		return;
 
 	if(m_aQmClientAuthToken[0] == '\0')
@@ -2787,21 +2873,18 @@ void CTClient::SyncQmClientUsers()
 		return;
 	}
 
-	SendQmClientPlayerData();
+	if(Client()->State() == IClient::STATE_ONLINE)
+		SendQmClientPlayerData();
 	FetchQmClientUsers();
 }
 
 void CTClient::UpdateQmClientRecognition()
 {
-	if(Client()->State() != IClient::STATE_ONLINE)
+	const bool Online = Client()->State() == IClient::STATE_ONLINE;
+	if(!Online)
 	{
-		if(m_pQmClientAuthTokenTask || m_pQmClientUsersTask || m_pQmClientUsersSendTask || m_aQmClientAuthToken[0] != '\0' || m_QmClientLastSync != 0)
-		{
-			ResetQmClientRecognitionTasks();
-			GameClient()->ClearQ1menGSyncMarks();
-			GameClient()->ClearQmVoiceSyncMarks();
-		}
-		return;
+		GameClient()->ClearQ1menGSyncMarks();
+		GameClient()->ClearQmVoiceSyncMarks();
 	}
 
 	if(m_pQmClientAuthTokenTask && m_pQmClientAuthTokenTask->Done())
@@ -3022,7 +3105,6 @@ void CTClient::CheckFreezeWakeupPopup()
 		return;
 	}
 
-	const int DamageTickWindow = maximum(2, GameClient()->m_PredictedWorld.GameTickSpeed() / 6);
 	for(int Dummy = 0; Dummy < NUM_DUMMIES; ++Dummy)
 	{
 		if(Dummy == 1 && !Client()->DummyConnected())
@@ -3048,19 +3130,8 @@ void CTClient::CheckFreezeWakeupPopup()
 		const bool IsInFreeze = ClientData.m_FreezeEnd != 0;
 		if(m_aWasInFreezeForWakeupPopup[Dummy] && !IsInFreeze)
 		{
-			if(const CCharacter *pPredictedChar = GameClient()->m_PredictedWorld.GetCharacterById(ClientId))
-			{
-				const int LastDamageTick = pPredictedChar->GetLastDamageTick();
-				const int DamageTickDelta = GameClient()->m_PredictedWorld.GameTick() - LastDamageTick;
-				const bool HammerWakeup = LastDamageTick > 0 &&
-					DamageTickDelta >= 0 &&
-					DamageTickDelta <= DamageTickWindow &&
-					pPredictedChar->GetLastDamageWeapon() == WEAPON_HAMMER &&
-					pPredictedChar->GetLastDamageFrom() >= 0 &&
-					pPredictedChar->GetLastDamageFrom() != ClientId;
-				if(HammerWakeup)
-					AddFreezeWakeupPopup(Dummy);
-			}
+			if(DetectFreezeWakeupType(GameClient(), ClientId) == EFreezeWakeupType::EXTERNAL_HAMMER)
+				AddFreezeWakeupPopup(Dummy);
 		}
 
 		m_aWasInFreezeForWakeupPopup[Dummy] = IsInFreeze;
@@ -3555,6 +3626,12 @@ void CTClient::CheckAutoUnspecOnUnfreeze()
 		// 检测从 freeze 到 unfreeze 的转换
 		if(m_aWasInFreezeForUnspec[Dummy] && !IsInFreeze && IsSpectating)
 		{
+			if(DetectFreezeWakeupType(GameClient(), ClientId) != EFreezeWakeupType::EXTERNAL_HAMMER)
+			{
+				m_aWasInFreezeForUnspec[Dummy] = IsInFreeze;
+				continue;
+			}
+
 			// 被解冻了，且当前处于旁观状态，直接发送网络包（最快方式）
 			if(Client()->IsSixup())
 			{
@@ -3613,19 +3690,23 @@ void CTClient::CheckAutoSwitchOnUnfreeze()
 
 	// 当前操控的是哪个 (0=本体, 1=dummy)
 	int CurrentDummy = g_Config.m_ClDummy;
+	const bool MainJustUnfrozen = MainWasInFreeze && !MainInFreeze;
+	const bool DummyJustUnfrozen = DummyWasInFreeze && !DummyInFreeze;
+	const bool MainExternalHammerWakeup = MainJustUnfrozen && DetectFreezeWakeupType(GameClient(), MainClientId) == EFreezeWakeupType::EXTERNAL_HAMMER;
+	const bool DummyExternalHammerWakeup = DummyJustUnfrozen && DetectFreezeWakeupType(GameClient(), DummyClientId) == EFreezeWakeupType::EXTERNAL_HAMMER;
 
 	// 核心逻辑：两个都曾被freeze，现在有一个解冻了
 	// 如果解冻的不是当前操控的，就切换
 	if(MainWasInFreeze && DummyWasInFreeze)
 	{
 		// 本体刚解冻，而当前操控的是dummy
-		if(!MainInFreeze && DummyInFreeze && CurrentDummy == 1)
+		if(!MainInFreeze && DummyInFreeze && CurrentDummy == 1 && MainExternalHammerWakeup)
 		{
 			// 切换到本体
 			Console()->ExecuteLine("cl_dummy 0");
 		}
 		// dummy刚解冻，而当前操控的是本体
-		else if(MainInFreeze && !DummyInFreeze && CurrentDummy == 0)
+		else if(MainInFreeze && !DummyInFreeze && CurrentDummy == 0 && DummyExternalHammerWakeup)
 		{
 			// 切换到dummy
 			Console()->ExecuteLine("cl_dummy 1");
@@ -3661,6 +3742,12 @@ void CTClient::CheckAutoCloseChatOnUnfreeze()
 
 		if(m_aWasInFreezeForChatClose[Dummy] && !IsInFreeze && CanCloseChat)
 		{
+			if(DetectFreezeWakeupType(GameClient(), ClientId) != EFreezeWakeupType::EXTERNAL_HAMMER)
+			{
+				m_aWasInFreezeForChatClose[Dummy] = IsInFreeze;
+				continue;
+			}
+
 			GameClient()->m_Chat.SaveDraft();
 			GameClient()->m_Chat.DisableMode();
 			CanCloseChat = false;

--- a/src/game/client/components/qmclient/qmclient.h
+++ b/src/game/client/components/qmclient/qmclient.h
@@ -93,6 +93,13 @@ struct SPlayerStats
 	}
 };
 
+struct SQmClientServerDistribution
+{
+	std::string m_ServerAddress;
+	int m_UserCount = 0;
+	int m_DummyCount = 0;
+};
+
 class CTClient : public CComponent
 {
 	std::deque<vec2> m_aAirRescuePositions[NUM_DUMMIES];
@@ -293,6 +300,9 @@ class CTClient : public CComponent
 	int64_t m_QmClientMarkerStartedAt = 0;
 	int64_t m_QmClientMarkerLastSeenAt = 0;
 	int64_t m_QmClientMarkerLastFlushTick = 0;
+	std::vector<SQmClientServerDistribution> m_vQmClientServerDistribution;
+	int m_QmClientOnlineUserCount = 0;
+	int m_QmClientOnlineDummyCount = 0;
 	bool m_QmClientShutdownReported = false;
 	bool m_QmClientAwaitingRecoveryStop = false;
 	bool m_QmClientStartupSent = false;
@@ -306,6 +316,7 @@ class CTClient : public CComponent
 	void ResetQmClientRecognitionTasks();
 	bool EnsureQmClientMachineHash();
 	bool BuildQmClientRecognitionUrl(const char *pPath, char *pBuf, size_t BufSize, const char *pQuery = nullptr) const;
+	void ClearQmClientServerDistribution();
 	void InitQmClientLifecycle();
 	void UpdateQmClientLifecycleAndServerTime();
 	void SendQmClientLifecyclePing(const char *pEvent, std::shared_ptr<CHttpRequest> &pTaskSlot);
@@ -393,6 +404,9 @@ public:
 	int64_t QmServerSessionStartTime() const { return m_QmClientServerSessionStart; }
 	bool HasQmServerPlaytime() const { return m_QmClientServerPlaytimeSeconds >= 0; }
 	int64_t QmServerPlaytimeSeconds() const { return m_QmClientServerPlaytimeSeconds; }
+	const std::vector<SQmClientServerDistribution> &QmClientServerDistribution() const { return m_vQmClientServerDistribution; }
+	int QmClientOnlineUserCount() const { return m_QmClientOnlineUserCount; }
+	int QmClientOnlineDummyCount() const { return m_QmClientOnlineDummyCount; }
 	int QmDdnetTotalFinishes() const { return m_QmDdnetTotalFinishes; }
 	const char *QmDdnetFavoritePartner() const { return m_aQmDdnetFavoritePartner; }
 	bool IsGoresMapProgressEnabled() const;

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -54,6 +54,34 @@ static size_t SkinNameVarSize(int Dummy)
 	return Dummy ? sizeof(g_Config.m_ClDummySkin) : sizeof(g_Config.m_ClPlayerSkin);
 }
 
+static int &SkinUseCustomColorVar(int Dummy)
+{
+	return Dummy ? g_Config.m_ClDummyUseCustomColor : g_Config.m_ClPlayerUseCustomColor;
+}
+
+static unsigned &SkinBodyColorVar(int Dummy)
+{
+	return Dummy ? g_Config.m_ClDummyColorBody : g_Config.m_ClPlayerColorBody;
+}
+
+static unsigned &SkinFeetColorVar(int Dummy)
+{
+	return Dummy ? g_Config.m_ClDummyColorFeet : g_Config.m_ClPlayerColorFeet;
+}
+
+static CSkins::CSkinQueueEntry MakeSkinQueueEntry(const char *pSkinName, bool UseCustomColor, int ColorBody, int ColorFeet)
+{
+	CSkins::CSkinQueueEntry Entry;
+	Entry.m_SkinName = pSkinName;
+	Entry.m_UseCustomColor = UseCustomColor;
+	if(UseCustomColor)
+	{
+		Entry.m_ColorBody = ColorBody;
+		Entry.m_ColorFeet = ColorFeet;
+	}
+	return Entry;
+}
+
 CSkins::CAbstractSkinLoadJob::CAbstractSkinLoadJob(CSkins *pSkins, const char *pName) :
 	m_pSkins(pSkins)
 {
@@ -523,10 +551,14 @@ void CSkins::OnConsoleInit()
 	Console()->Register("remove_favorite_skin", "s[skin_name]", CFGFLAG_CLIENT, ConRemFavoriteSkin, this, "Remove a skin from the favorites");
 	Console()->Register("add_skin_queue", "s[skin_name]", CFGFLAG_CLIENT, ConAddSkinQueue, this, "Add a skin to the queue");
 	Console()->Register("add_dummy_skin_queue", "s[skin_name]", CFGFLAG_CLIENT, ConAddDummySkinQueue, this, "Add a skin to the dummy queue");
+	Console()->Register("add_skin_queue_ex", "s[skin_name] i[use_custom_color] i[color_body] i[color_feet]", CFGFLAG_CLIENT, ConAddSkinQueueEx, this, "Add a colored skin to the queue");
+	Console()->Register("add_dummy_skin_queue_ex", "s[skin_name] i[use_custom_color] i[color_body] i[color_feet]", CFGFLAG_CLIENT, ConAddDummySkinQueueEx, this, "Add a colored skin to the dummy queue");
 	Console()->Register("add_skin_queue_preset", "s[preset_name]", CFGFLAG_CLIENT, ConAddSkinQueuePreset, this, "Add a queue preset");
 	Console()->Register("add_dummy_skin_queue_preset", "s[preset_name]", CFGFLAG_CLIENT, ConAddDummySkinQueuePreset, this, "Add a dummy queue preset");
 	Console()->Register("add_skin_queue_preset_item", "i[preset_index] s[skin_name]", CFGFLAG_CLIENT, ConAddSkinQueuePresetItem, this, "Add a skin to a queue preset");
 	Console()->Register("add_dummy_skin_queue_preset_item", "i[preset_index] s[skin_name]", CFGFLAG_CLIENT, ConAddDummySkinQueuePresetItem, this, "Add a skin to a dummy queue preset");
+	Console()->Register("add_skin_queue_preset_item_ex", "i[preset_index] s[skin_name] i[use_custom_color] i[color_body] i[color_feet]", CFGFLAG_CLIENT, ConAddSkinQueuePresetItemEx, this, "Add a colored skin to a queue preset");
+	Console()->Register("add_dummy_skin_queue_preset_item_ex", "i[preset_index] s[skin_name] i[use_custom_color] i[color_body] i[color_feet]", CFGFLAG_CLIENT, ConAddDummySkinQueuePresetItemEx, this, "Add a colored skin to a dummy queue preset");
 
 	Console()->Chain("player_skin", ConchainRefreshSkinList, this);
 	Console()->Chain("dummy_skin", ConchainRefreshSkinList, this);
@@ -609,11 +641,39 @@ void CSkins::ApplySkinQueueCurrent(int Dummy)
 	}
 
 	ClampSkinQueueIndex(Dummy);
-	const char *pTargetSkin = Queue[SkinQueueIndexVar(Dummy)].c_str();
+	const CSkinQueueEntry &TargetEntry = Queue[SkinQueueIndexVar(Dummy)];
 	char *pSkinName = SkinNameVar(Dummy);
-	if(str_comp(pSkinName, pTargetSkin) != 0)
+	int &UseCustomColor = SkinUseCustomColorVar(Dummy);
+	unsigned &ColorBody = SkinBodyColorVar(Dummy);
+	unsigned &ColorFeet = SkinFeetColorVar(Dummy);
+
+	bool Changed = false;
+	if(str_comp(pSkinName, TargetEntry.m_SkinName.c_str()) != 0)
 	{
-		str_copy(pSkinName, pTargetSkin, SkinNameVarSize(Dummy));
+		str_copy(pSkinName, TargetEntry.m_SkinName.c_str(), SkinNameVarSize(Dummy));
+		Changed = true;
+	}
+	if(UseCustomColor != (int)TargetEntry.m_UseCustomColor)
+	{
+		UseCustomColor = TargetEntry.m_UseCustomColor ? 1 : 0;
+		Changed = true;
+	}
+	if(TargetEntry.m_UseCustomColor)
+	{
+		if(ColorBody != (unsigned)TargetEntry.m_ColorBody)
+		{
+			ColorBody = TargetEntry.m_ColorBody;
+			Changed = true;
+		}
+		if(ColorFeet != (unsigned)TargetEntry.m_ColorFeet)
+		{
+			ColorFeet = TargetEntry.m_ColorFeet;
+			Changed = true;
+		}
+	}
+
+	if(Changed)
+	{
 		m_SkinList.ForceRefresh();
 		if(Dummy == 0)
 		{
@@ -688,7 +748,7 @@ void CSkins::SyncSkinQueueFromMapPlayers(int Dummy)
 	}
 
 	const int Limit = maximum(0, SkinQueueLengthVar(Dummy));
-	std::vector<std::string> vMapSkins;
+	std::vector<CSkinQueueEntry> vMapSkins;
 	vMapSkins.reserve(Limit > 0 ? (size_t)std::min(Limit, (int)MAX_CLIENTS) : 0);
 
 	for(int ClientId = 0; ClientId < MAX_CLIENTS; ++ClientId)
@@ -699,9 +759,15 @@ void CSkins::SyncSkinQueueFromMapPlayers(int Dummy)
 			continue;
 		}
 
-		const char *pSkinName = GameClient()->m_aClients[ClientId].m_aSkinName;
-		if(!CSkin::IsValidName(pSkinName) ||
-			std::find(vMapSkins.begin(), vMapSkins.end(), pSkinName) != vMapSkins.end())
+		const auto &ClientData = GameClient()->m_aClients[ClientId];
+		const char *pSkinName = ClientData.m_aSkinName;
+		if(!CSkin::IsValidName(pSkinName))
+		{
+			continue;
+		}
+
+		const CSkinQueueEntry Entry = MakeSkinQueueEntry(pSkinName, ClientData.m_UseCustomColor != 0, ClientData.m_ColorBody, ClientData.m_ColorFeet);
+		if(std::find(vMapSkins.begin(), vMapSkins.end(), Entry) != vMapSkins.end())
 		{
 			continue;
 		}
@@ -710,7 +776,7 @@ void CSkins::SyncSkinQueueFromMapPlayers(int Dummy)
 		{
 			break;
 		}
-		vMapSkins.emplace_back(pSkinName);
+		vMapSkins.push_back(Entry);
 	}
 
 	auto &Queue = m_aSkinQueue[Dummy];
@@ -719,7 +785,7 @@ void CSkins::SyncSkinQueueFromMapPlayers(int Dummy)
 		return;
 	}
 
-	std::string CurrentSkin;
+	std::optional<CSkinQueueEntry> CurrentSkin;
 	if(!Queue.empty())
 	{
 		ClampSkinQueueIndex(Dummy);
@@ -733,9 +799,9 @@ void CSkins::SyncSkinQueueFromMapPlayers(int Dummy)
 	{
 		QueueIndex = 0;
 	}
-	else if(!CurrentSkin.empty())
+	else if(CurrentSkin.has_value())
 	{
-		const auto It = std::find(Queue.begin(), Queue.end(), CurrentSkin);
+		const auto It = std::find(Queue.begin(), Queue.end(), CurrentSkin.value());
 		QueueIndex = It != Queue.end() ? (int)(It - Queue.begin()) : 0;
 	}
 	ClampSkinQueueIndex(Dummy);
@@ -1090,11 +1156,22 @@ bool CSkins::IsFavorite(const char *pName) const
 
 bool CSkins::IsInSkinQueue(const char *pName, int Dummy) const
 {
-	const auto &Queue = m_aSkinQueue[Dummy];
-	return std::find(Queue.begin(), Queue.end(), pName) != Queue.end();
+	return IsInSkinQueue(pName, false, 0, 0, Dummy);
 }
 
 bool CSkins::AddSkinQueue(const char *pName, int Dummy)
+{
+	return AddSkinQueue(pName, false, 0, 0, Dummy);
+}
+
+bool CSkins::IsInSkinQueue(const char *pName, bool UseCustomColor, int ColorBody, int ColorFeet, int Dummy) const
+{
+	const auto &Queue = m_aSkinQueue[Dummy];
+	const CSkinQueueEntry Entry = MakeSkinQueueEntry(pName, UseCustomColor, ColorBody, ColorFeet);
+	return std::find(Queue.begin(), Queue.end(), Entry) != Queue.end();
+}
+
+bool CSkins::AddSkinQueue(const char *pName, bool UseCustomColor, int ColorBody, int ColorFeet, int Dummy)
 {
 	if(!CSkin::IsValidName(pName))
 	{
@@ -1103,7 +1180,7 @@ bool CSkins::AddSkinQueue(const char *pName, int Dummy)
 		return false;
 	}
 
-	if(IsInSkinQueue(pName, Dummy))
+	if(IsInSkinQueue(pName, UseCustomColor, ColorBody, ColorFeet, Dummy))
 	{
 		return false;
 	}
@@ -1114,15 +1191,25 @@ bool CSkins::AddSkinQueue(const char *pName, int Dummy)
 		return false;
 	}
 
-	Queue.emplace_back(pName);
+	Queue.push_back(MakeSkinQueueEntry(pName, UseCustomColor, ColorBody, ColorFeet));
 	ClampSkinQueueIndex(Dummy);
 	return true;
 }
 
 bool CSkins::RemoveSkinQueue(const char *pName, int Dummy)
 {
+	return RemoveSkinQueue(pName, false, 0, 0, Dummy);
+}
+
+bool CSkins::RemoveSkinQueue(const char *pName, bool UseCustomColor, int ColorBody, int ColorFeet, int Dummy)
+{
+	return RemoveSkinQueue(MakeSkinQueueEntry(pName, UseCustomColor, ColorBody, ColorFeet), Dummy);
+}
+
+bool CSkins::RemoveSkinQueue(const CSkinQueueEntry &Entry, int Dummy)
+{
 	auto &Queue = m_aSkinQueue[Dummy];
-	auto It = std::find(Queue.begin(), Queue.end(), pName);
+	auto It = std::find(Queue.begin(), Queue.end(), Entry);
 	if(It == Queue.end())
 	{
 		return false;
@@ -1147,7 +1234,7 @@ void CSkins::MoveSkinQueueItem(size_t FromIndex, size_t ToIndex, int Dummy)
 		return;
 	}
 
-	std::string Moving = std::move(Queue[FromIndex]);
+	CSkinQueueEntry Moving = std::move(Queue[FromIndex]);
 	Queue.erase(Queue.begin() + FromIndex);
 	Queue.insert(Queue.begin() + ToIndex, std::move(Moving));
 
@@ -1197,6 +1284,11 @@ bool CSkins::AddSkinQueuePreset(const char *pName, int Dummy)
 
 bool CSkins::AddSkinQueuePresetItem(int PresetIndex, const char *pSkinName, int Dummy)
 {
+	return AddSkinQueuePresetItem(PresetIndex, pSkinName, false, 0, 0, Dummy);
+}
+
+bool CSkins::AddSkinQueuePresetItem(int PresetIndex, const char *pSkinName, bool UseCustomColor, int ColorBody, int ColorFeet, int Dummy)
+{
 	auto &Presets = m_aSkinQueuePresets[Dummy];
 	if(PresetIndex < 0 || PresetIndex >= (int)Presets.size())
 	{
@@ -1208,9 +1300,10 @@ bool CSkins::AddSkinQueuePresetItem(int PresetIndex, const char *pSkinName, int 
 	}
 
 	auto &Queue = Presets[PresetIndex].m_Queue;
-	if(std::find(Queue.begin(), Queue.end(), pSkinName) == Queue.end())
+	const CSkinQueueEntry Entry = MakeSkinQueueEntry(pSkinName, UseCustomColor, ColorBody, ColorFeet);
+	if(std::find(Queue.begin(), Queue.end(), Entry) == Queue.end())
 	{
-		Queue.emplace_back(pSkinName);
+		Queue.push_back(Entry);
 	}
 	return true;
 }
@@ -1519,6 +1612,18 @@ void CSkins::ConAddDummySkinQueue(IConsole::IResult *pResult, void *pUserData)
 	pSelf->AddSkinQueue(pResult->GetString(0), 1);
 }
 
+void CSkins::ConAddSkinQueueEx(IConsole::IResult *pResult, void *pUserData)
+{
+	auto *pSelf = static_cast<CSkins *>(pUserData);
+	pSelf->AddSkinQueue(pResult->GetString(0), pResult->GetInteger(1) != 0, pResult->GetInteger(2), pResult->GetInteger(3), 0);
+}
+
+void CSkins::ConAddDummySkinQueueEx(IConsole::IResult *pResult, void *pUserData)
+{
+	auto *pSelf = static_cast<CSkins *>(pUserData);
+	pSelf->AddSkinQueue(pResult->GetString(0), pResult->GetInteger(1) != 0, pResult->GetInteger(2), pResult->GetInteger(3), 1);
+}
+
 void CSkins::ConAddSkinQueuePreset(IConsole::IResult *pResult, void *pUserData)
 {
 	auto *pSelf = static_cast<CSkins *>(pUserData);
@@ -1541,6 +1646,18 @@ void CSkins::ConAddDummySkinQueuePresetItem(IConsole::IResult *pResult, void *pU
 {
 	auto *pSelf = static_cast<CSkins *>(pUserData);
 	pSelf->AddSkinQueuePresetItem(pResult->GetInteger(0), pResult->GetString(1), 1);
+}
+
+void CSkins::ConAddSkinQueuePresetItemEx(IConsole::IResult *pResult, void *pUserData)
+{
+	auto *pSelf = static_cast<CSkins *>(pUserData);
+	pSelf->AddSkinQueuePresetItem(pResult->GetInteger(0), pResult->GetString(1), pResult->GetInteger(2) != 0, pResult->GetInteger(3), pResult->GetInteger(4), 0);
+}
+
+void CSkins::ConAddDummySkinQueuePresetItemEx(IConsole::IResult *pResult, void *pUserData)
+{
+	auto *pSelf = static_cast<CSkins *>(pUserData);
+	pSelf->AddSkinQueuePresetItem(pResult->GetInteger(0), pResult->GetString(1), pResult->GetInteger(2) != 0, pResult->GetInteger(3), pResult->GetInteger(4), 1);
 }
 
 void CSkins::ConfigSaveCallback(IConfigManager *pConfigManager, void *pUserData)
@@ -1567,17 +1684,53 @@ void CSkins::ConfigSaveQueueCallback(IConfigManager *pConfigManager, void *pUser
 
 void CSkins::OnQueueConfigSave(IConfigManager *pConfigManager)
 {
+	const auto WriteQueueEntry = [pConfigManager](const CSkinQueueEntry &Entry, bool Dummy, int PresetIndex) {
+		char aBuffer[160 + MAX_SKIN_LENGTH];
+		if(PresetIndex < 0)
+		{
+			if(Entry.m_UseCustomColor)
+			{
+				str_format(aBuffer, sizeof(aBuffer), "%s \"%s\" %d %d %d",
+					Dummy ? "add_dummy_skin_queue_ex" : "add_skin_queue_ex",
+					Entry.m_SkinName.c_str(),
+					Entry.m_UseCustomColor ? 1 : 0,
+					Entry.m_ColorBody,
+					Entry.m_ColorFeet);
+			}
+			else
+			{
+				str_format(aBuffer, sizeof(aBuffer), "%s \"%s\"",
+					Dummy ? "add_dummy_skin_queue" : "add_skin_queue",
+					Entry.m_SkinName.c_str());
+			}
+		}
+		else if(Entry.m_UseCustomColor)
+		{
+			str_format(aBuffer, sizeof(aBuffer), "%s %d \"%s\" %d %d %d",
+				Dummy ? "add_dummy_skin_queue_preset_item_ex" : "add_skin_queue_preset_item_ex",
+				PresetIndex,
+				Entry.m_SkinName.c_str(),
+				Entry.m_UseCustomColor ? 1 : 0,
+				Entry.m_ColorBody,
+				Entry.m_ColorFeet);
+		}
+		else
+		{
+			str_format(aBuffer, sizeof(aBuffer), "%s %d \"%s\"",
+				Dummy ? "add_dummy_skin_queue_preset_item" : "add_skin_queue_preset_item",
+				PresetIndex,
+				Entry.m_SkinName.c_str());
+		}
+		pConfigManager->WriteLine(aBuffer, ConfigDomain::QIMENG);
+	};
+
 	for(const auto &QueueSkin : m_aSkinQueue[0])
 	{
-		char aBuffer[32 + MAX_SKIN_LENGTH];
-		str_format(aBuffer, sizeof(aBuffer), "add_skin_queue \"%s\"", QueueSkin.c_str());
-		pConfigManager->WriteLine(aBuffer, ConfigDomain::QIMENG);
+		WriteQueueEntry(QueueSkin, false, -1);
 	}
 	for(const auto &QueueSkin : m_aSkinQueue[1])
 	{
-		char aBuffer[40 + MAX_SKIN_LENGTH];
-		str_format(aBuffer, sizeof(aBuffer), "add_dummy_skin_queue \"%s\"", QueueSkin.c_str());
-		pConfigManager->WriteLine(aBuffer, ConfigDomain::QIMENG);
+		WriteQueueEntry(QueueSkin, true, -1);
 	}
 
 	for(int Dummy = 0; Dummy < NUM_DUMMIES; ++Dummy)
@@ -1595,14 +1748,7 @@ void CSkins::OnQueueConfigSave(IConfigManager *pConfigManager)
 			}
 
 			for(const auto &QueueSkin : Preset.m_Queue)
-			{
-				char aBuffer[80 + MAX_SKIN_LENGTH];
-				if(Dummy == 0)
-					str_format(aBuffer, sizeof(aBuffer), "add_skin_queue_preset_item %d \"%s\"", PresetIndex, QueueSkin.c_str());
-				else
-					str_format(aBuffer, sizeof(aBuffer), "add_dummy_skin_queue_preset_item %d \"%s\"", PresetIndex, QueueSkin.c_str());
-				pConfigManager->WriteLine(aBuffer, ConfigDomain::QIMENG);
-			}
+				WriteQueueEntry(QueueSkin, Dummy != 0, PresetIndex);
 			PresetIndex++;
 		}
 	}

--- a/src/game/client/components/skins.h
+++ b/src/game/client/components/skins.h
@@ -252,18 +252,40 @@ public:
 	void RemoveFavorite(const char *pName);
 	bool IsFavorite(const char *pName) const;
 
+	class CSkinQueueEntry
+	{
+	public:
+		std::string m_SkinName;
+		bool m_UseCustomColor = false;
+		int m_ColorBody = 0;
+		int m_ColorFeet = 0;
+
+		bool operator==(const CSkinQueueEntry &Other) const
+		{
+			if(m_SkinName != Other.m_SkinName || m_UseCustomColor != Other.m_UseCustomColor)
+				return false;
+			if(!m_UseCustomColor)
+				return true;
+			return m_ColorBody == Other.m_ColorBody && m_ColorFeet == Other.m_ColorFeet;
+		}
+	};
+
 	class CSkinQueuePreset
 	{
 	public:
 		std::string m_Name;
-		std::vector<std::string> m_Queue;
+		std::vector<CSkinQueueEntry> m_Queue;
 	};
 
-	const std::vector<std::string> &SkinQueue(int Dummy) const { return m_aSkinQueue[Dummy]; }
+	const std::vector<CSkinQueueEntry> &SkinQueue(int Dummy) const { return m_aSkinQueue[Dummy]; }
 	const std::vector<CSkinQueuePreset> &SkinQueuePresets(int Dummy) const { return m_aSkinQueuePresets[Dummy]; }
 	bool IsInSkinQueue(const char *pName, int Dummy) const;
+	bool IsInSkinQueue(const char *pName, bool UseCustomColor, int ColorBody, int ColorFeet, int Dummy) const;
 	bool AddSkinQueue(const char *pName, int Dummy);
+	bool AddSkinQueue(const char *pName, bool UseCustomColor, int ColorBody, int ColorFeet, int Dummy);
 	bool RemoveSkinQueue(const char *pName, int Dummy);
+	bool RemoveSkinQueue(const char *pName, bool UseCustomColor, int ColorBody, int ColorFeet, int Dummy);
+	bool RemoveSkinQueue(const CSkinQueueEntry &Entry, int Dummy);
 	void MoveSkinQueueItem(size_t FromIndex, size_t ToIndex, int Dummy);
 	void TrimSkinQueueToLimit(int Dummy);
 	bool AddSkinQueuePresetFromCurrent(int Dummy);
@@ -327,7 +349,7 @@ private:
 
 	CSkinList m_SkinList;
 	std::set<std::string> m_Favorites;
-	std::array<std::vector<std::string>, NUM_DUMMIES> m_aSkinQueue;
+	std::array<std::vector<CSkinQueueEntry>, NUM_DUMMIES> m_aSkinQueue;
 	std::array<std::vector<CSkinQueuePreset>, NUM_DUMMIES> m_aSkinQueuePresets;
 	std::array<std::chrono::nanoseconds, NUM_DUMMIES> m_aSkinQueueElapsed = {};
 	std::array<std::optional<std::chrono::nanoseconds>, NUM_DUMMIES> m_aSkinQueueLastUpdate = {};
@@ -351,10 +373,14 @@ private:
 	void OnConfigSave(IConfigManager *pConfigManager);
 	static void ConAddSkinQueue(IConsole::IResult *pResult, void *pUserData);
 	static void ConAddDummySkinQueue(IConsole::IResult *pResult, void *pUserData);
+	static void ConAddSkinQueueEx(IConsole::IResult *pResult, void *pUserData);
+	static void ConAddDummySkinQueueEx(IConsole::IResult *pResult, void *pUserData);
 	static void ConAddSkinQueuePreset(IConsole::IResult *pResult, void *pUserData);
 	static void ConAddDummySkinQueuePreset(IConsole::IResult *pResult, void *pUserData);
 	static void ConAddSkinQueuePresetItem(IConsole::IResult *pResult, void *pUserData);
 	static void ConAddDummySkinQueuePresetItem(IConsole::IResult *pResult, void *pUserData);
+	static void ConAddSkinQueuePresetItemEx(IConsole::IResult *pResult, void *pUserData);
+	static void ConAddDummySkinQueuePresetItemEx(IConsole::IResult *pResult, void *pUserData);
 	static void ConfigSaveQueueCallback(IConfigManager *pConfigManager, void *pUserData);
 	void OnQueueConfigSave(IConfigManager *pConfigManager);
 	static void ConchainRefreshSkinList(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
@@ -364,6 +390,7 @@ private:
 	void ClampSkinQueueIndex(int Dummy);
 	bool AddSkinQueuePreset(const char *pName, int Dummy);
 	bool AddSkinQueuePresetItem(int PresetIndex, const char *pSkinName, int Dummy);
+	bool AddSkinQueuePresetItem(int PresetIndex, const char *pSkinName, bool UseCustomColor, int ColorBody, int ColorFeet, int Dummy);
 
 	friend class CSkinProfiles;
 };

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -109,35 +109,11 @@ int FastInputPredictionTicks(float OffsetTicks)
 	return (int)std::ceil(OffsetTicks);
 }
 
-void ApplyFastInputOffset(float OffsetTicks, int &Tick, float &Intra)
-{
-	if(OffsetTicks <= 0.0f)
-		return;
-
-	const int WholeTicks = (int)OffsetTicks;
-	const float OffsetIntra = OffsetTicks - WholeTicks;
-
-	const float CombinedIntra = Intra + OffsetIntra;
-	const int CarryOverTicks = (int)CombinedIntra;
-
-	Tick += WholeTicks + CarryOverTicks;
-	Intra = CombinedIntra - CarryOverTicks;
-}
-
 bool EffectiveFastInputOthers()
 {
 	return g_Config.m_TcFastInputOthers != 0;
 }
 
-bool EffectiveAnyFastInputOthers()
-{
-	return EffectiveFastInputOthers();
-}
-
-bool EffectiveImmediateFastInputOthers()
-{
-	return EffectiveFastInputOthers();
-}
 } // namespace
 
 const char *CGameClient::Version() const { return GAME_VERSION; }
@@ -640,7 +616,6 @@ void CGameClient::OnDummySwap()
 	}
 	const int PrevDummyFire = m_DummyInput.m_Fire;
 	m_DummyInput = m_Controls.m_aInputData[!g_Config.m_ClDummy];
-	m_DummyControlReleaseFlags = 0;
 	m_Controls.m_aInputData[g_Config.m_ClDummy].m_Fire = PrevDummyFire;
 	m_IsDummySwapping = 1;
 }
@@ -718,8 +693,7 @@ bool CGameClient::GetDummyFastInput(CNetObj_PlayerInput &DummyFastInput, const C
 		if(g_Config.m_ClDummyControl)
 		{
 			const CNetObj_PlayerInput BaseDummyInput = pDummyInputData ? *pDummyInputData : CNetObj_PlayerInput{};
-			if(g_Config.m_ClDummyLeft || g_Config.m_ClDummyRight)
-				DummyFastInput.m_Direction = BaseDummyInput.m_Direction;
+			DummyFastInput.m_Direction = BaseDummyInput.m_Direction;
 			DummyFastInput.m_Jump = BaseDummyInput.m_Jump;
 			DummyFastInput.m_Fire = BaseDummyInput.m_Fire;
 			DummyFastInput.m_Hook = BaseDummyInput.m_Hook;
@@ -731,10 +705,6 @@ bool CGameClient::GetDummyFastInput(CNetObj_PlayerInput &DummyFastInput, const C
 	{
 		const CNetObj_PlayerInput BaseDummyInput = pDummyInputData ? *pDummyInputData : CNetObj_PlayerInput{};
 		DummyFastInput = BaseDummyInput;
-		if(g_Config.m_ClDummyLeft || g_Config.m_ClDummyRight)
-			DummyFastInput.m_Direction = BaseDummyInput.m_Direction;
-		else
-			DummyFastInput.m_Direction = m_Controls.m_aFastInput[DummyTee].m_Direction;
 		DummyFastInput.m_PlayerFlags = m_Controls.m_aFastInput[DummyTee].m_PlayerFlags;
 		DummyFastInput.m_TargetX = m_Controls.m_aFastInput[DummyTee].m_TargetX;
 		DummyFastInput.m_TargetY = m_Controls.m_aFastInput[DummyTee].m_TargetY;
@@ -854,7 +824,6 @@ void CGameClient::OnReset()
 	std::fill(std::begin(m_aNextChangeInfo), std::end(m_aNextChangeInfo), -1);
 	std::fill(std::begin(m_aLocalIds), std::end(m_aLocalIds), -1);
 	m_DummyInput = {};
-	m_DummyControlReleaseFlags = 0;
 	m_HammerInput = {};
 	m_DummyFire = 0;
 	m_ReceivedDDNetPlayer = false;
@@ -3283,7 +3252,7 @@ void CGameClient::OnPredict()
 	// prediction actually happens here
 
 	const int FastInputTicks = GetFastInputPredictionTicks();
-	const bool FastInputOthers = EffectiveAnyFastInputOthers();
+	const bool FastInputOthers = EffectiveFastInputOthers();
 
 	int FinalTickRegular = Client()->PredGameTick(g_Config.m_ClDummy); // The vanilla final tick disregarding fast input
 	int FinalTickSelf = FinalTickRegular + FastInputTicks; // the final tick for just our local tee
@@ -4806,10 +4775,6 @@ void CGameClient::UpdateSpectatorCursor()
 
 void CGameClient::UpdateRenderedCharacters()
 {
-	const float FastInputOffsetTicks = EffectiveFastInputOffsetTicks(this);
-	const int FastInputTicks = FastInputPredictionTicks(FastInputOffsetTicks);
-	const bool HasFastInput = FastInputTicks > 0;
-	const bool FastInputOthers = EffectiveAnyFastInputOthers();
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
 		if(!m_Snap.m_aCharacters[i].m_Active)
@@ -4844,12 +4809,12 @@ void CGameClient::UpdateRenderedCharacters()
 
 			if(IsPracticeParticipant)
 			{
-				if(HasFastInput && (i == m_Snap.m_LocalClientId || FastInputOthers))
+				if(g_Config.m_TcFastInput && (i == m_Snap.m_LocalClientId || g_Config.m_TcFastInputOthers))
 					Pos = GetFastInputPos(i);
 			}
 			else if(g_Config.m_TcRemoveAnti)
 				Pos = GetFreezePos(i);
-			else if(HasFastInput && (i == m_Snap.m_LocalClientId || (PredictDummy() && i == m_aLocalIds[!g_Config.m_ClDummy])))
+			else if(g_Config.m_TcFastInput && (i == m_Snap.m_LocalClientId || (PredictDummy() && i == m_aLocalIds[!g_Config.m_ClDummy])))
 			{
 				Pos = GetFastInputPos(i);
 			}
@@ -4873,15 +4838,12 @@ void CGameClient::UpdateRenderedCharacters()
 				if(g_Config.m_ClAntiPingSmooth)
 					Pos = GetSmoothPos(i);
 
-				// Fast-input others should feel immediate: prefer direct fast-input position over smoothing layers.
-				if(HasFastInput && EffectiveImmediateFastInputOthers())
-					Pos = GetFastInputPos(i);
-				else if(g_Config.m_TcAntiPingImproved && m_aClients[i].m_ValidAntipingSmooth)
+				if(g_Config.m_TcAntiPingImproved && m_aClients[i].m_ValidAntipingSmooth)
 					Pos = mix(m_aClients[i].m_PrevImprovedPredPos, m_aClients[i].m_ImprovedPredPos, Client()->PredIntraGameTick(g_Config.m_ClDummy));
 
 				if(g_Config.m_TcRemoveAnti && m_pClient->m_IsLocalFrozen)
 					Pos = GetFreezePos(i);
-				else if(HasFastInput && FastInputOthers && !g_Config.m_TcAntiPingImproved)
+				else if(g_Config.m_TcFastInput && g_Config.m_TcFastInputOthers && !g_Config.m_TcAntiPingImproved)
 					Pos = GetFastInputPos(i);
 
 				if(g_Config.m_TcShowOthersGhosts && g_Config.m_TcSwapGhosts && !(m_aClients[i].m_FreezeEnd > 0 && g_Config.m_TcHideFrozenGhosts))
@@ -4983,13 +4945,9 @@ void CGameClient::DetectStrongHook()
 
 vec2 CGameClient::GetSmoothPos(int ClientId)
 {
-	const float FastInputOffsetTicks = EffectiveFastInputOffsetTicks(this);
-	const int FastInputTicks = FastInputPredictionTicks(FastInputOffsetTicks);
-	if(ClientId != m_Snap.m_LocalClientId && FastInputTicks > 0 && EffectiveImmediateFastInputOthers())
-		return GetFastInputPos(ClientId);
+	const int FastInputTicks = g_Config.m_TcFastInput ? (g_Config.m_TcFastInputAmount + 19) / 20 : 0;
 	vec2 Pos = mix(m_aClients[ClientId].m_PrevPredicted.m_Pos, m_aClients[ClientId].m_Predicted.m_Pos, Client()->PredIntraGameTick(g_Config.m_ClDummy));
 	int64_t Now = time_get();
-	const bool FastInputOthers = EffectiveAnyFastInputOthers();
 	for(int i = 0; i < 2; i++)
 	{
 		int64_t Len = std::clamp(m_aClients[ClientId].m_aSmoothLen[i], (int64_t)1, time_freq());
@@ -5001,10 +4959,8 @@ vec2 CGameClient::GetSmoothPos(int ClientId)
 			float SmoothIntra;
 			Client()->GetSmoothTick(&SmoothTick, &SmoothIntra, MixAmount);
 
-			if(ClientId != m_Snap.m_LocalClientId && FastInputOthers && FastInputTicks > 0)
-			{
-				ApplyFastInputOffset(FastInputOffsetTicks, SmoothTick, SmoothIntra);
-			}
+			if(ClientId != m_Snap.m_LocalClientId && g_Config.m_TcFastInputOthers && FastInputTicks > 0)
+				SmoothTick += FastInputTicks;
 
 			if(SmoothTick > 0 &&
 				m_aClients[ClientId].m_aPredTick[(SmoothTick - 1) % 200] >= Client()->PrevGameTick(g_Config.m_ClDummy) &&
@@ -5039,15 +4995,24 @@ vec2 CGameClient::GetFastInputPos(int ClientId)
 
 	vec2 Pos = mix(m_aClients[ClientId].m_PrevPredicted.m_Pos, m_aClients[ClientId].m_Predicted.m_Pos, PredIntraTick);
 
-	const float FastInputOffsetTicks = EffectiveFastInputOffsetTicks(this);
-	const int FastInputTicks = FastInputPredictionTicks(FastInputOffsetTicks);
-	ApplyFastInputOffset(FastInputOffsetTicks, PredTick, PredIntraTick);
+	float FastInputIntra = (g_Config.m_TcFastInputAmount % 20) / 20.0f;
+	int FastInputTicks = g_Config.m_TcFastInputAmount / 20;
 
-	if(PredTick > 0 &&
-		m_aClients[ClientId].m_aPredTick[(PredTick - 1) % 200] >= Client()->PrevGameTick(g_Config.m_ClDummy) &&
-		m_aClients[ClientId].m_aPredTick[PredTick % 200] <= Client()->PredGameTick(g_Config.m_ClDummy) + FastInputTicks)
+	float CombinedIntra = PredIntraTick + FastInputIntra;
+
+	float IntraRemainder = 0.0f;
+	float FinalIntra = std::modf(CombinedIntra, &IntraRemainder);
+	int CarryOverTicks = static_cast<int>(IntraRemainder);
+
+	FastInputTicks += CarryOverTicks;
+
+	int FinalTick = PredTick + FastInputTicks;
+
+	if(FinalTick > 0 &&
+		m_aClients[ClientId].m_aPredTick[(FinalTick - 1) % 200] >= Client()->PrevGameTick(g_Config.m_ClDummy) &&
+		m_aClients[ClientId].m_aPredTick[FinalTick % 200] <= Client()->PredGameTick(g_Config.m_ClDummy) + FastInputTicks)
 	{
-		Pos = mix(m_aClients[ClientId].m_aPredPos[(PredTick - 1) % 200], m_aClients[ClientId].m_aPredPos[PredTick % 200], PredIntraTick);
+		Pos = mix(m_aClients[ClientId].m_aPredPos[(FinalTick - 1) % 200], m_aClients[ClientId].m_aPredPos[FinalTick % 200], FinalIntra);
 	}
 
 	return Pos;
@@ -5055,11 +5020,6 @@ vec2 CGameClient::GetFastInputPos(int ClientId)
 
 vec2 CGameClient::GetFreezePos(int ClientId)
 {
-	const float FastInputOffsetTicks = EffectiveFastInputOffsetTicks(this);
-	const int FastInputTicks = FastInputPredictionTicks(FastInputOffsetTicks);
-	if(ClientId != m_Snap.m_LocalClientId && FastInputTicks > 0 && EffectiveImmediateFastInputOthers())
-		return GetFastInputPos(ClientId);
-	const bool FastInputOthers = EffectiveAnyFastInputOthers();
 	vec2 Pos = mix(m_aClients[ClientId].m_PrevPredicted.m_Pos, m_aClients[ClientId].m_Predicted.m_Pos, Client()->PredIntraGameTick(g_Config.m_ClDummy));
 	// int64_t Now = time_get();
 	CCharacter *pChar = m_PredictedWorld.GetCharacterById(m_Snap.m_LocalClientId);
@@ -5097,12 +5057,27 @@ vec2 CGameClient::GetFreezePos(int ClientId)
 	m_SmoothTick = SmoothTick;
 	m_SmoothIntraTick = SmoothIntra;
 
+	float FastInputIntra = (g_Config.m_TcFastInputAmount % 20) / 20.0f;
+	int FastInputTicks = g_Config.m_TcFastInputAmount / 20;
+
+	float CombinedIntra = SmoothIntra + FastInputIntra;
+
+	float IntraRemainder = 0.0f;
+	float FinalIntra = std::modf(CombinedIntra, &IntraRemainder);
+	int CarryOverTicks = static_cast<int>(IntraRemainder);
+
+	FastInputTicks += CarryOverTicks;
+
 	const bool IsLocal = ClientId == m_Snap.m_LocalClientId || (PredictDummy() && ClientId == m_aLocalIds[!g_Config.m_ClDummy]);
-	const bool ApplyFastInputLocal = IsLocal && FastInputTicks > 0;
-	const bool ApplyFastInputOthers = !IsLocal && FastInputOthers && FastInputTicks > 0;
-	if(ApplyFastInputLocal || ApplyFastInputOthers)
+	if(IsLocal && g_Config.m_TcFastInput)
 	{
-		ApplyFastInputOffset(FastInputOffsetTicks, SmoothTick, SmoothIntra);
+		SmoothTick += FastInputTicks;
+		SmoothIntra = FinalIntra;
+	}
+	else if(!IsLocal && g_Config.m_TcFastInputOthers && g_Config.m_TcFastInput)
+	{
+		SmoothTick += FastInputTicks;
+		SmoothIntra = FinalIntra;
 	}
 
 	if(SmoothTick > 0 &&

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -757,21 +757,12 @@ public:
 	void ApplyPreInputs(int Tick, bool Direct, CGameWorld &GameWorld);
 	bool GetDummyFastInput(CNetObj_PlayerInput &DummyFastInput, const CNetObj_PlayerInput *pDummyInputData, const class CCharacter *pDummyChar, int LocalTee, int DummyTee) const;
 
-	enum EDummyControlReleaseFlags
-	{
-		DUMMY_CONTROL_RELEASE_DIRECTION = 1 << 0,
-		DUMMY_CONTROL_RELEASE_JUMP = 1 << 1,
-		DUMMY_CONTROL_RELEASE_FIRE = 1 << 2,
-		DUMMY_CONTROL_RELEASE_HOOK = 1 << 3,
-	};
-
 	int m_aNextChangeInfo[NUM_DUMMIES];
 
 	// DDRace
 
 	int m_aLocalIds[NUM_DUMMIES];
 	CNetObj_PlayerInput m_DummyInput;
-	int m_DummyControlReleaseFlags{};
 	CNetObj_PlayerInput m_HammerInput;
 	unsigned int m_DummyFire;
 	bool m_ReceivedDDNetPlayer;


### PR DESCRIPTION
## **FEAT**
- 新增`Freeze`唤醒提示：当本体或`Dummy`从`Freeze`状态被锤醒时，会在对应玩家位置的随机左上角或右上角弹出“快醒醒!”提示。
- 唤醒提示已接入HJ大佬辅助模块，可通过独立开关控制显示。
- 唤醒提示现已跟随现有字体配置渲染，并支持随机彩虹高亮颜色、随机倾斜角度与限时消失效果。
- 补充并完善了大量配置项中文说明，覆盖`Qm`与`TClient`相关配置，便于直接在UI中理解用途。
- 优化HJ辅助,现在仅有外部锤醒才生效
- `cl_dummy_right/left`逻辑使用官方逻辑
- `fast input`回归`TClient`
- 新增浏览器页签Qm
- 新增`QmClient`在线人数分布

## **FIX**
- 修复唤醒提示字体固定的问题，改为跟随当前字体配置显示。
- 修复唤醒提示文案与位置逻辑，现统一为“快醒醒!”，并按玩家实际位置随机显示在左上或右上，而不是固定角落。
- 修复分身小窗在目标距离过远或离开当前视角时不显示的问题，优化离屏/远距离场景下的显示逻辑。
- 修复部分界面与截图中的汉化缺失问题，补齐相关文案翻译。
- 精修配置项中文说明，清理机翻味、中英混杂和表达不准确的问题，使说明更自然统一。
- 修复HUD多余可调整项

## **DEL**
- 删除`qm_nameplate_coord_x_align_hint`及其对应UI。
- 删除`qm_fast`及其附属配置，并移除对应UI。
- 删除`qm_unfinished_map_*`相关配置。
- 删除`qm_hookcoll_mode`配置。
- 将原`ri_`前缀配置统一替换为`qm_`前缀。