### PR TITLE
fix: polish qmclient combo, chat, and hud behavior

### DIFF
--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -206,9 +206,6 @@ bool CBinds::CBindsSpecial::OnInput(const IInput::CEvent &Event)
 		return m_pBinds->OnInput(Event);
 	}
 
-	if(GameClient()->m_Chat.IsActive() && m_pBinds->HasChatToggleCursorBind(Event))
-		return m_pBinds->OnInput(Event);
-
 	return false;
 }
 
@@ -294,20 +291,6 @@ int CBinds::GetModifierMaskOfKey(int Key)
 	default:
 		return KeyModifier::NONE;
 	}
-}
-
-bool CBinds::HasChatToggleCursorBind(const IInput::CEvent &Event) const
-{
-	const int KeyModifierMask = GetModifierMaskOfKey(Event.m_Key);
-	const int ModifierMask = GetModifierMask(Input()) & ~KeyModifierMask;
-
-	if(BindContainsCommand(m_aapKeyBindings[ModifierMask][Event.m_Key], "toggle_scoreboard_cursor"))
-		return true;
-
-	return m_aapKeyBindings[KeyModifier::NONE][Event.m_Key] &&
-		ModifierMask != ((1 << KeyModifier::CTRL) | (1 << KeyModifier::SHIFT)) &&
-		ModifierMask != ((1 << KeyModifier::GUI) | (1 << KeyModifier::SHIFT)) &&
-		BindContainsCommand(m_aapKeyBindings[KeyModifier::NONE][Event.m_Key], "toggle_scoreboard_cursor");
 }
 
 bool CBinds::OnInput(const IInput::CEvent &Event)

--- a/src/game/client/components/binds.h
+++ b/src/game/client/components/binds.h
@@ -92,7 +92,6 @@ public:
 	void SetDDRaceBinds(bool FreeOnly);
 
 private:
-	bool HasChatToggleCursorBind(const IInput::CEvent &Event) const;
 	char *m_aapKeyBindings[KeyModifier::COMBINATION_COUNT][KEY_LAST];
 	std::vector<CBindSlot> m_vActiveBinds;
 };

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -364,12 +364,12 @@ void CChat::LockMouse()
 	m_LastMousePos = Ui()->MousePos();
 }
 
-void CChat::ToggleMouseUnlocked()
+void CChat::UnlockMouse()
 {
-	if(!IsActive() || GameClient()->m_Menus.IsActive() || Client()->State() == IClient::STATE_DEMOPLAYBACK)
+	if(m_MouseUnlocked || !IsActive() || GameClient()->m_Menus.IsActive() || Client()->State() == IClient::STATE_DEMOPLAYBACK)
 		return;
 
-	m_MouseUnlocked = !m_MouseUnlocked;
+	m_MouseUnlocked = true;
 
 	vec2 OldMousePos = Ui()->MousePos();
 	if(m_LastMousePos == std::nullopt)
@@ -550,12 +550,6 @@ bool CChat::OnInput(const IInput::CEvent &Event)
 {
 	if(m_Mode == MODE_NONE)
 		return false;
-
-	if(m_MouseUnlocked && Event.m_Flags & IInput::FLAG_PRESS && Event.m_Key == KEY_ESCAPE)
-	{
-		LockMouse();
-		return true;
-	}
 
 	if(Event.m_Flags & IInput::FLAG_PRESS && Event.m_Key == KEY_ESCAPE)
 	{
@@ -847,6 +841,7 @@ void CChat::EnableMode(int Team)
 		m_CompletionChosen = -1;
 		m_CompletionUsed = false;
 		m_Input.Activate(EInputPriority::CHAT);
+		UnlockMouse();
 	}
 }
 

--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -175,6 +175,7 @@ class CChat : public CComponent
 
 	bool LineShouldHighlight(const char *pLine, const char *pName);
 	void LockMouse();
+	void UnlockMouse();
 	void SetUiMousePos(vec2 Pos);
 	void StoreSave(const char *pText);
 	void SendChatQueued(int Team, const char *pLine, bool AllowOutgoingTranslation);
@@ -203,7 +204,6 @@ public:
 	void RegisterCommand(const char *pName, const char *pParams, const char *pHelpText);
 	void UnregisterCommand(const char *pName);
 	void Echo(const char *pString);
-	void ToggleMouseUnlocked();
 
 	void OnWindowResize() override;
 	void OnConsoleInit() override;

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -126,12 +126,6 @@ void CScoreboard::ConToggleScoreboardCursor(IConsole::IResult *pResult, void *pU
 {
 	CScoreboard *pSelf = static_cast<CScoreboard *>(pUserData);
 
-	if(pSelf->GameClient()->m_Chat.IsActive())
-	{
-		pSelf->GameClient()->m_Chat.ToggleMouseUnlocked();
-		return;
-	}
-
 	if(!pSelf->IsActive() ||
 		pSelf->GameClient()->m_Menus.IsActive() ||
 		pSelf->Client()->State() == IClient::STATE_DEMOPLAYBACK)


### PR DESCRIPTION
## FEAT
- Combo Popups 新增汉化，并接入当前全局文本/字体渲染管线
- DDRace HUD 的“显示分身状态”元素接入 HUD 编辑器

## FIX
- 列表中好友优先级高于战队成员
- 自动翻译开关默认值改为 0
- Combo Popups 现在受全局文本控制，修正文字倒置，并改为在 `#00FFFF` 到 `#FF00FF` 之间滚动渐变
- Combo Popups 持续时间调整为 1.25s，修复切换字体时闪退，并清理窗口/字体重建后的旧缓存
- Hook / Fire 连击状态可正确混合累计，不再互相覆盖
- 修复支持 SMTC 的音乐软件在游戏启动后再打开时可能触发的崩溃路径
- 聊天框开启时默认显示鼠标，并保持文本输入可用，不再依赖 `toggle_scoreboard_cursor`
- QmClient 版本号按 patch 规则升级到 2.35.1

## DEL
- 删除梦的小功能中的消息动画、计分板动画、表情动画及其对应动画逻辑
- 删除梦的小功能中的 Q弹Tee 开关 UI
- 删除旧的 `config_variables_qimeng.h`