### PR TITLE
feat(qmclient): 完成页面切换优化与体验增强

### DIFF
--- a/data/languages/simplified_chinese.txt
+++ b/data/languages/simplified_chinese.txt
@@ -6470,3 +6470,33 @@ Community links, updates, feedback, and supporter credits moved to Contributors
 
 Drag, collapse, search, and usage history are preserved inside each category
 == 拖拽、折叠、搜索和使用频率记录会继续保留在各自分类中
+
+Concurrency
+== 并发数
+
+Max concurrent translations
+== 最大并发翻译数
+
+Translate
+== 翻译
+
+Thinking Mode
+== 思考模式
+
+Enable thinking mode (slower)
+== 启用思考模式（较慢）
+
+Enable thinking mode requires using reasoning models
+== 启用思考模式请使用推理模型
+
+Ensure backend supports OpenAI-compatible thinking parameter
+== 请确保后端支持 OpenAI 兼容的 thinking 参数
+
+Downloaded
+== 已下载
+
+Not downloaded
+== 未下载
+
+Hide overhead direction and hook indicators
+== 隐藏头顶方向键和强弱钩提示

--- a/data/languages/traditional_chinese.txt
+++ b/data/languages/traditional_chinese.txt
@@ -3386,7 +3386,49 @@ Changing name to %s near finish
 
 [translate]
 %s translating to %s
-== 
+== %s 翻譯為 %s
+
+%s translating to %s before send
+== %s 正在翻譯為 %s 後傳送
+
+Translating to %s...
+== 正在翻譯為 %s...
+
+Not a valid ID
+== 無效的 ID
+
+ID not connected
+== 該 ID 未連線
+
+No message to translate
+== 沒有可翻譯的訊息
+
+Server messages are not translated
+== 伺服器訊息不會被翻譯
+
+Invalid translate backend
+== 無效的翻譯後端
+
+Too many translation jobs
+== 翻譯任務過多
+
+Translation queue full, sending original text
+== 翻譯佇列已滿，發送原始文字
+
+Invalid translate backend, sending original text
+== 翻譯後端無效，發送原始文字
+
+You are not in practice
+== 你目前不在練習模式中
+
+No safe position found
+== 未找到安全位置
+
+No local saves file found (ddnet-saves.txt)
+== 未找到本地存檔檔案（ddnet-saves.txt）
+
+Failed to read saves file
+== 讀取存檔檔案失敗
 
 [translate]
 %s to %s failed: %s
@@ -3436,3 +3478,155 @@ Community links, updates, feedback, and supporter credits moved to Contributors
 
 Drag, collapse, search, and usage history are preserved inside each category
 == 拖曳、折疊、搜尋與使用頻率記錄會繼續保留在各自分類中
+
+Visual: Font & Cursor
+== 視覺：字體與游標
+
+Visual: Nameplates
+== 視覺：名牌
+
+Visual: Effects
+== 視覺：特效
+
+Show ping colored circle in nameplates
+== 在玩家暱稱旁顯示延遲顏色圓圈
+
+Show country flags in nameplates
+== 在玩家暱稱旁顯示國旗
+
+Show skin names in nameplate
+== 在玩家暱稱旁顯示皮膚名
+
+Use colored skins for frozen tees
+== 凍結 Tee 使用彩色皮膚
+
+Show katan on frozen players
+== 在被凍結的玩家身上顯示武士刀
+
+Render all custom colored feet as white feet skin
+== 將所有自訂腳部顏色渲染為白色
+
+Automatic concurrency: %d (smart default)
+== 自動並發數：%d（智慧預設）
+
+Manual concurrency: %d
+== 手動並發數：%d
+
+Commands run in the console
+== 在控制台中執行的命令
+
+L select  R swap  M select only
+== 左鍵選取  右鍵交換  中鍵僅選取
+
+L select  R swap
+== 左鍵選取  右鍵交換
+
+Status Bar Codes:
+== 狀態欄代碼：
+
+a = Angle
+== a = Angle（角度）
+
+p = Ping
+== p = Ping（延遲）
+
+d = Prediction
+== d = Prediction（預測）
+
+c = Position
+== c = Position（位置）
+
+l = Local Time
+== l = Local Time（本地時間）
+
+r = Race Time
+== r = Race Time（競速時間）
+
+f = FPS
+== f = FPS（每秒幀數）
+
+v = Velocity
+== v = Velocity（速度）
+
+z = Zoom
+== z = Zoom（縮放）
+
+_ or ' ' = Space
+== _ 或 ' ' = 空白
+
+Apply
+== 套用
+
+Status Scheme:
+== 狀態欄方案：
+
+Add Item
+== 新增項目
+
+Remove Item
+== 移除項目
+
+Text color
+== 文字顏色
+
+Displays your current angle in degrees
+== 顯示你目前的角度（度）
+
+Displays your ping to the current server
+== 顯示你到目前伺服器的延遲
+
+Displays your current prediction amount
+== 顯示你目前的預測量
+
+Displays position
+== 顯示目前位置
+
+Displays your local time
+== 顯示你的本地時間
+
+Display your race time
+== 顯示你的競速時間
+
+Displays your frames per second
+== 顯示你目前的每秒幀數
+
+Displays X and Y velocity
+== 顯示 X 與 Y 方向速度
+
+Displays current zoom value
+== 顯示目前縮放值
+
+Gap between statusbar items
+== 狀態欄項目之間的間隔
+
+Downloaded
+== 已下載
+
+Not downloaded
+== 未下載
+
+Thank you for your companionship and belief, which gave me the courage to keep going
+== 感謝你們一路以來的陪伴與信任，讓我有勇氣繼續走下去
+
+Hide overhead direction and hook indicators
+== 隱藏頭頂方向鍵與強弱鉤提示
+Hide guides
+== 隱藏輔助線
+
+Auto login Axiom server
+== 自動登入 Axiom 伺服器
+
+Axiom login password
+== Axiom 登入密碼
+
+Attempting Axiom auto login
+== 正在嘗試自動登入 Axiom 伺服器
+
+Axiom auto login succeeded
+== Axiom 自動登入成功
+
+Axiom auto login failed, retrying
+== Axiom 自動登入失敗，正在重試
+
+Axiom auto login failed
+== Axiom 自動登入失敗

--- a/src/engine/shared/config_variables_qmclient_extra.h
+++ b/src/engine/shared/config_variables_qmclient_extra.h
@@ -18,6 +18,9 @@ MACRO_CONFIG_INT(QmGoresDisableIfWeapons, qm_gores_disable_if_weapons, 1, 0, 1, 
 MACRO_CONFIG_INT(QmGoresAutoEnable, qm_gores_auto_enable, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "在 Gores 游戏模式中自动启用 Gores 自动切换")
 MACRO_CONFIG_INT(QmGoresFastInput, qm_gores_fast_input, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Gores 模式下启用快速输入")
 MACRO_CONFIG_INT(QmGoresFastInputOthers, qm_gores_fast_input_others, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Gores 模式下对其他玩家也启用快速输入")
+MACRO_CONFIG_INT(QmGoresHideGuides, qm_gores_hide_guides, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Gores 模式下隐藏辅助线")
+MACRO_CONFIG_INT(QmAxiomAutoLogin, qm_axiom_auto_login, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "进入 Axiom 社区服务器后自动登录")
+MACRO_CONFIG_STR(QmAxiomLoginPassword, qm_axiom_login_password, 128, "", CFGFLAG_CLIENT | CFGFLAG_SAVE, "Axiom 服务器自动登录密码")
 
 // Focus Mode (Zen Mode)
 MACRO_CONFIG_INT(QmFocusMode, qm_focus_mode, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "启用专注模式（Zen Mode）")
@@ -27,6 +30,7 @@ MACRO_CONFIG_INT(QmFocusModeHideHud, qm_focus_mode_hide_hud, 0, 0, 1, CFGFLAG_CL
 MACRO_CONFIG_INT(QmFocusModeHideChat, qm_focus_mode_hide_chat, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "专注模式下隐藏聊天")
 MACRO_CONFIG_INT(QmFocusModeHideUI, qm_focus_mode_hide_ui, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "专注模式下隐藏非必要 UI 元素")
 MACRO_CONFIG_INT(QmFocusModeHideScoreboard, qm_focus_mode_hide_scoreboard, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "专注模式下隐藏计分板")
+MACRO_CONFIG_INT(QmFocusModeHideOverheadIndicators, qm_focus_mode_hide_overhead_indicators, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "专注模式下隐藏头顶方向键和强弱钩提示")
 
 // Player Stats HUD
 MACRO_CONFIG_INT(QmPlayerStatsHud, qm_player_stats_hud, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "启用玩家统计 HUD")

--- a/src/game/client/QmUi/QmRt.cpp
+++ b/src/game/client/QmUi/QmRt.cpp
@@ -55,7 +55,8 @@ void CUiRuntimeV2::OnRender()
 	if(g_Config.m_QmUiRuntimeV2Debug)
 	{
 		m_DebugLogAccumulator += Dt;
-		if(m_DebugLogAccumulator >= 2.0f)
+		const double PerfDebugThresholdMs = g_Config.m_QmPerfDebugThresholdMs > 0 ? g_Config.m_QmPerfDebugThresholdMs : 1.0;
+		if(m_DebugLogAccumulator >= 2.0f && m_LastStats.m_AnimMs >= PerfDebugThresholdMs)
 		{
 			m_DebugLogAccumulator = 0.0f;
 			dbg_msg("qm_ui", "runtime active: nodes=%d, anim_ms=%.3f", m_LastStats.m_NodeCount, m_LastStats.m_AnimMs);

--- a/src/game/client/QmUi/QmRt.cpp
+++ b/src/game/client/QmUi/QmRt.cpp
@@ -55,8 +55,7 @@ void CUiRuntimeV2::OnRender()
 	if(g_Config.m_QmUiRuntimeV2Debug)
 	{
 		m_DebugLogAccumulator += Dt;
-		const double PerfDebugThresholdMs = g_Config.m_QmPerfDebugThresholdMs > 0 ? g_Config.m_QmPerfDebugThresholdMs : 1.0;
-		if(m_DebugLogAccumulator >= 2.0f && m_LastStats.m_AnimMs >= PerfDebugThresholdMs)
+		if(m_DebugLogAccumulator >= 2.0f)
 		{
 			m_DebugLogAccumulator = 0.0f;
 			dbg_msg("qm_ui", "runtime active: nodes=%d, anim_ms=%.3f", m_LastStats.m_NodeCount, m_LastStats.m_AnimMs);

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -2694,7 +2694,7 @@ void CMenus::RenderServerbrowserQm(CUIRect View)
 	View.HSplitTop(5.0f, nullptr, &View);
 	View.HSplitTop(28.0f, &Summary, &View);
 
-	if(g_Config.m_QmVoiceServer[0] == '\0')
+	if(!GameClient()->m_TClient.HasQmClientRecognitionService())
 	{
 		Ui()->DoLabel(&Summary, Localize("Set a voice server to enable QmClient distribution"), 9.0f, TEXTALIGN_ML);
 		return;

--- a/src/game/client/components/menus_settings_assets.cpp
+++ b/src/game/client/components/menus_settings_assets.cpp
@@ -2022,12 +2022,21 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 			static size_t s_PendingDownloadAssetIndex = SIZE_MAX;
 			static CUi::SConfirmPopupContext s_WorkshopDownloadConfirmPopup;
 
-			constexpr int MaxThumbStartsPerFrame = 2; // Keep low to avoid frame hitches
+			constexpr int MaxThumbStartsPerFrame = 16;
 			int ThumbStartsThisFrame = 0;
 			int OldCombinedSelected = -1;
 			bool DeleteLocalRequested = false;
 			char aDeleteLocalName[50] = "";
 			bool WorkshopActionTriggered = false;
+			auto RenderAssetStatusTag = [&](const CUIRect &CardRect, bool Downloaded) {
+				CUIRect TagRect = CardRect;
+				TagRect.HSplitTop(16.0f, &TagRect, nullptr);
+				TagRect.VSplitLeft(58.0f, &TagRect, nullptr);
+				TagRect.Margin(3.0f, &TagRect);
+				const ColorRGBA TagColor = Downloaded ? ColorRGBA(0.18f, 0.62f, 0.32f, 0.88f) : ColorRGBA(0.52f, 0.52f, 0.58f, 0.82f);
+				TagRect.Draw(TagColor, IGraphics::CORNER_ALL, 5.0f);
+				Ui()->DoLabel(&TagRect, Localize(Downloaded ? "Downloaded" : "Not downloaded"), 7.5f, TEXTALIGN_MC);
+			};
 
 			for(size_t ListIndex = 0; ListIndex < CombinedCount; ++ListIndex)
 			{
@@ -2050,10 +2059,13 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 
 					const CUIRect CardRect = ItemRect;
 
-					CUIRect TextureRect;
-					ItemRect.HSplitTop(15, &ItemRect, &TextureRect);
-					TextureRect.HSplitTop(10, nullptr, &TextureRect);
-					Ui()->DoLabel(&ItemRect, pItem->m_aName, ItemRect.h - 2, TEXTALIGN_MC);
+			CUIRect TextureRect, HeaderRect, NameRect;
+			ItemRect.HSplitTop(18.0f, &HeaderRect, &TextureRect);
+			TextureRect.HSplitTop(10, nullptr, &TextureRect);
+			NameRect = HeaderRect;
+			NameRect.VSplitLeft(62.0f, nullptr, &NameRect);
+			NameRect.VSplitRight(30.0f, &NameRect, nullptr);
+			Ui()->DoLabel(&NameRect, pItem->m_aName, HeaderRect.h - 2, TEXTALIGN_MC);
 					if(s_CurCustomTab == ASSETS_TAB_ENTITIES && s_EntityGamePreview)
 					{
 						const auto *pEntitiesItem = static_cast<const SCustomEntities *>(pItem);
@@ -2147,7 +2159,9 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 						}
 					}
 
-					if(str_comp(pItem->m_aName, "default") != 0)
+			RenderAssetStatusTag(CardRect, true);
+
+			if(str_comp(pItem->m_aName, "default") != 0)
 					{
 						CUIRect DeleteButton = CardRect;
 						DeleteButton.HSplitTop(20.0f, &DeleteButton, nullptr);
@@ -2198,10 +2212,13 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 					}
 
 					const CUIRect CardRect = ItemRect;
-					CUIRect TextureRect;
-					ItemRect.HSplitTop(15, &ItemRect, &TextureRect);
+					CUIRect TextureRect, HeaderRect, NameRect;
+					ItemRect.HSplitTop(18.0f, &HeaderRect, &TextureRect);
 					TextureRect.HSplitTop(10, nullptr, &TextureRect);
-					Ui()->DoLabel(&ItemRect, Asset.m_Name.c_str(), ItemRect.h - 2, TEXTALIGN_MC);
+					NameRect = HeaderRect;
+					NameRect.VSplitLeft(62.0f, nullptr, &NameRect);
+					NameRect.VSplitRight(30.0f, &NameRect, nullptr);
+					Ui()->DoLabel(&NameRect, Asset.m_Name.c_str(), HeaderRect.h - 2, TEXTALIGN_MC);
 
 					if(s_CurCustomTab == ASSETS_TAB_ENTITIES && s_EntityGamePreview && Asset.m_ThumbTexture.IsValid())
 					{
@@ -2265,6 +2282,8 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 						LoadingRect.Draw(ColorRGBA(0.0f, 0.0f, 0.0f, 0.10f), IGraphics::CORNER_ALL, 6.0f);
 						Ui()->DoLabel(&LoadingRect, Localize("Loading..."), 10.0f, TEXTALIGN_MC);
 					}
+
+					RenderAssetStatusTag(CardRect, Asset.m_Installed);
 
 					const bool Downloading = Asset.m_pDownloadTask && !Asset.m_pDownloadTask->Done();
 					CUIRect DownloadButton = CardRect;

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -1438,6 +1438,7 @@ void CNamePlates::RenderNamePlateGame(vec2 Position, const CNetObj_PlayerInfo *p
 		ShowDirectionConfig = g_Config.m_ClVideoShowDirection;
 #endif
 	Data.m_DirLeft = Data.m_DirJump = Data.m_DirRight = false;
+	const bool HideOverheadIndicators = g_Config.m_QmFocusMode && g_Config.m_QmFocusModeHideOverheadIndicators;
 	switch(ShowDirectionConfig)
 	{
 	case 0: // Off
@@ -1455,6 +1456,8 @@ void CNamePlates::RenderNamePlateGame(vec2 Position, const CNetObj_PlayerInfo *p
 	default:
 		dbg_assert_failed("ShowDirectionConfig invalid");
 	}
+	if(HideOverheadIndicators)
+		Data.m_ShowDirection = false;
 	if(Data.m_ShowDirection)
 	{
 		if(Client()->State() != IClient::STATE_DEMOPLAYBACK &&
@@ -1487,7 +1490,7 @@ void CNamePlates::RenderNamePlateGame(vec2 Position, const CNetObj_PlayerInfo *p
 	Data.m_HookStrongWeakId = 0;
 
 	const bool Following = (GameClient()->m_Snap.m_SpecInfo.m_Active && !GameClient()->m_MultiViewActivated && GameClient()->m_Snap.m_SpecInfo.m_SpectatorId != SPEC_FREEVIEW);
-	if(GameClient()->m_Snap.m_LocalClientId != -1 || Following)
+	if(!HideOverheadIndicators && (GameClient()->m_Snap.m_LocalClientId != -1 || Following))
 	{
 		const int SelectedId = Following ? GameClient()->m_Snap.m_SpecInfo.m_SpectatorId : GameClient()->m_Snap.m_LocalClientId;
 		if(SelectedId >= 0 && SelectedId < MAX_CLIENTS)
@@ -1655,6 +1658,8 @@ void CNamePlates::RenderChatBubble(vec2 Position, int ClientId, float Alpha)
 {
 	// Check if chat bubbles are enabled
 	if(!g_Config.m_QmChatBubble)
+		return;
+	if(g_Config.m_QmFocusMode && g_Config.m_QmFocusModeHideChat)
 		return;
 
 	if(ClientId < 0 || ClientId >= MAX_CLIENTS)

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -245,6 +245,9 @@ void CPlayers::RenderHookCollLine(
 	const CNetObj_Character *pPlayerChar,
 	int ClientId)
 {
+	if(GameClient()->m_TClient.ShouldHideGoresGuides())
+		return;
+
 	// TClient
 	if(ClientId >= 0 && GameClient()->m_aClients[ClientId].m_IsVolleyBall)
 		return;
@@ -546,6 +549,9 @@ void CPlayers::RenderWeaponTrajectory(
 	const CNetObj_Character *pPlayerChar,
 	int ClientId)
 {
+	if(GameClient()->m_TClient.ShouldHideGoresGuides())
+		return;
+
 	if(ClientId < 0 || !g_Config.m_QmWeaponTrajectory || !GameClient()->m_Controls.m_aShowWeaponTrajectory[g_Config.m_ClDummy])
 		return;
 

--- a/src/game/client/components/qmclient/menus_qmclient.cpp
+++ b/src/game/client/components/qmclient/menus_qmclient.cpp
@@ -2185,7 +2185,7 @@ void CMenus::RenderSettingsTClientStatusBar(CUIRect MainView)
 	StatusScheme.HSplitTop(MarginSmall, nullptr, &StatusScheme);
 
 	if(s_TypeSelectedOld >= 0)
-		Ui()->DoLabel(&ItemLabel, GameClient()->m_StatusBar.m_StatusItemTypes[s_TypeSelectedOld].m_aDesc, FontSize, TEXTALIGN_ML);
+		Ui()->DoLabel(&ItemLabel, Localize(GameClient()->m_StatusBar.m_StatusItemTypes[s_TypeSelectedOld].m_aDesc), FontSize, TEXTALIGN_ML);
 
 	StatusScheme.VSplitMid(&StatusButtons, &StatusScheme, MarginSmall);
 	StatusScheme.VSplitMid(&Label, &StatusScheme, MarginSmall);
@@ -2201,10 +2201,20 @@ void CMenus::RenderSettingsTClientStatusBar(CUIRect MainView)
 	s_StatusScheme.SetEmptyText("");
 	Ui()->DoEditBox(&s_StatusScheme, &StatusScheme, EditBoxFontSize);
 
-	static std::vector<const char *> s_DropDownNames = {};
-	for(const CStatusItem &StatusItemType : GameClient()->m_StatusBar.m_StatusItemTypes)
-		if(s_DropDownNames.size() != GameClient()->m_StatusBar.m_StatusItemTypes.size())
-			s_DropDownNames.push_back(StatusItemType.m_aName);
+	static std::vector<std::string> s_DropDownNameStorage;
+	static std::vector<const char *> s_DropDownNames;
+	if(s_DropDownNameStorage.size() != GameClient()->m_StatusBar.m_StatusItemTypes.size())
+	{
+		s_DropDownNameStorage.clear();
+		s_DropDownNames.clear();
+		s_DropDownNameStorage.reserve(GameClient()->m_StatusBar.m_StatusItemTypes.size());
+		s_DropDownNames.reserve(GameClient()->m_StatusBar.m_StatusItemTypes.size());
+		for(const CStatusItem &StatusItemType : GameClient()->m_StatusBar.m_StatusItemTypes)
+		{
+			s_DropDownNameStorage.emplace_back(Localize(StatusItemType.m_aName));
+			s_DropDownNames.push_back(s_DropDownNameStorage.back().c_str());
+		}
+	}
 
 	static CUi::SDropDownState s_DropDownState;
 	static CScrollRegion s_DropDownScrollRegion;
@@ -2311,7 +2321,7 @@ void CMenus::RenderSettingsTClientStatusBar(CUIRect MainView)
 			float Progress = std::pow(2.0, -5.0 * (1.0 - s_ItemSwaps[i].m_Duration / 0.15f));
 			TempItemButton.x = mix(TempItemButton.x, s_ItemSwaps[i].m_InitialPosition.x, Progress);
 		}
-		if(DoButtonLineSize_Menu(s_pItemButtons[i], StatusItem->m_aDisplayName, 0, &TempItemButton, LineSize, false, 0, IGraphics::CORNER_ALL, 5.0f, 0.0f, Col))
+		if(DoButtonLineSize_Menu(s_pItemButtons[i], Localize(StatusItem->m_aDisplayName), 0, &TempItemButton, LineSize, false, 0, IGraphics::CORNER_ALL, 5.0f, 0.0f, Col))
 		{
 			if(s_SelectedItem == -2)
 				s_SelectedItem++;

--- a/src/game/client/components/qmclient/qmclient.cpp
+++ b/src/game/client/components/qmclient/qmclient.cpp
@@ -77,6 +77,21 @@ static constexpr const char *DDNET_PLAYER_STATS_URL = "https://ddnet.org/players
 static constexpr int QMCLIENT_DDNET_PLAYER_SYNC_INTERVAL_SECONDS = 120;
 static constexpr int QMCLIENT_DDNET_PLAYER_RETRY_DELAY_SECONDS = 10;
 static constexpr const char *QMCLIENT_FREEZE_WAKEUP_TEXT = "快醒醒!";
+static constexpr int QMCLIENT_AXIOM_AUTO_LOGIN_MAX_ATTEMPTS = 3;
+static constexpr int QMCLIENT_AXIOM_AUTO_LOGIN_RETRY_DELAY_SECONDS = 2;
+
+static bool TextContainsAny(const char *pText, const std::initializer_list<const char *> &Tokens)
+{
+	if(!pText || pText[0] == '\0')
+		return false;
+
+	for(const char *pToken : Tokens)
+	{
+		if(pToken && pToken[0] != '\0' && str_find_nocase(pText, pToken))
+			return true;
+	}
+	return false;
+}
 static constexpr float QMCLIENT_FREEZE_WAKEUP_POPUP_DURATION = 2.0f;
 static constexpr float QMCLIENT_COMBO_POPUP_DURATION = 1.25f;
 static constexpr float QMCLIENT_TEXT_POPUP_FONT_SIZE = 30.0f;
@@ -543,6 +558,11 @@ static bool ParseQmClientServiceHostPort(const char *pAddrStr, char *pHost, size
 
 	Port = str_toint(pColon + 1);
 	return Port > 0 && Port <= 65535;
+}
+
+const char *GetEffectiveQmVoiceServer()
+{
+	return g_Config.m_QmVoiceServer;
 }
 
 static void TrimQmClientTextInPlace(char *pText)
@@ -1645,6 +1665,123 @@ const char *CTClient::CurrentCommunityIdForFinishCheck() const
 	return pCommunityId;
 }
 
+bool CTClient::IsAxiomCommunity() const
+{
+	const char *pCommunityId = CurrentCommunityIdForFinishCheck();
+	if(!pCommunityId)
+		return false;
+
+	if(str_find_nocase(pCommunityId, "axiom"))
+		return true;
+
+	IServerBrowser *pServerBrowser = ServerBrowser();
+	if(!pServerBrowser)
+		return false;
+
+	const CCommunity *pCommunity = pServerBrowser->Community(pCommunityId);
+	return pCommunity && pCommunity->Name() && str_find_nocase(pCommunity->Name(), "axiom");
+}
+
+void CTClient::ResetAxiomAutoLoginState()
+{
+	m_AxiomAutoLoginAnnounced = false;
+	m_AxiomAutoLoginSucceeded = false;
+	m_AxiomAutoLoginWaitingReply = false;
+	m_AxiomAutoLoginAttempts = 0;
+	m_AxiomAutoLoginNextTryTick = 0;
+	m_aAxiomAutoLoginServer[0] = '\0';
+}
+
+void CTClient::TrySendAxiomLogin()
+{
+	if(g_Config.m_QmAxiomAutoLogin == 0 || g_Config.m_QmAxiomLoginPassword[0] == '\0')
+		return;
+	if(Client()->State() != IClient::STATE_ONLINE || !IsAxiomCommunity())
+		return;
+	if(m_AxiomAutoLoginSucceeded || m_AxiomAutoLoginAttempts >= QMCLIENT_AXIOM_AUTO_LOGIN_MAX_ATTEMPTS)
+		return;
+
+	char aServerAddress[NETADDR_MAXSTRSIZE] = "";
+	net_addr_str(&Client()->ServerAddress(), aServerAddress, sizeof(aServerAddress), true);
+	if(aServerAddress[0] != '\0')
+		str_copy(m_aAxiomAutoLoginServer, aServerAddress, sizeof(m_aAxiomAutoLoginServer));
+
+	char aLoginCommand[192];
+	str_format(aLoginCommand, sizeof(aLoginCommand), "/login %s", g_Config.m_QmAxiomLoginPassword);
+	GameClient()->m_Chat.SendChat(0, aLoginCommand);
+
+	m_AxiomAutoLoginAttempts++;
+	m_AxiomAutoLoginWaitingReply = true;
+	m_AxiomAutoLoginNextTryTick = 0;
+
+	if(!m_AxiomAutoLoginAnnounced)
+	{
+		GameClient()->Echo(Localize("Attempting Axiom auto login"));
+		m_AxiomAutoLoginAnnounced = true;
+	}
+}
+
+void CTClient::HandleAxiomAutoLoginMessage(const char *pText)
+{
+	if(!m_AxiomAutoLoginWaitingReply || !IsAxiomCommunity() || !pText || pText[0] == '\0')
+		return;
+
+	const bool IsLoginMessage = TextContainsAny(pText, {"login", "logged in", "登入", "登录"});
+	if(!IsLoginMessage)
+		return;
+
+	const bool Success = TextContainsAny(pText, {"success", "successful", "logged in", "welcome", "succeeded", "登入成功", "登录成功", "欢迎"});
+	const bool Failure = TextContainsAny(pText, {"fail", "failed", "incorrect", "invalid", "wrong", "denied", "error", "password incorrect", "登入失败", "登录失败", "密码错误"});
+
+	if(Success)
+	{
+		m_AxiomAutoLoginSucceeded = true;
+		m_AxiomAutoLoginWaitingReply = false;
+		m_AxiomAutoLoginNextTryTick = 0;
+		GameClient()->Echo(Localize("Axiom auto login succeeded"));
+	}
+	else if(Failure)
+	{
+		m_AxiomAutoLoginWaitingReply = false;
+		if(m_AxiomAutoLoginAttempts < QMCLIENT_AXIOM_AUTO_LOGIN_MAX_ATTEMPTS)
+		{
+			m_AxiomAutoLoginNextTryTick = time_get() + (int64_t)QMCLIENT_AXIOM_AUTO_LOGIN_RETRY_DELAY_SECONDS * time_freq();
+			GameClient()->Echo(Localize("Axiom auto login failed, retrying"));
+		}
+		else
+		{
+			m_AxiomAutoLoginNextTryTick = 0;
+			GameClient()->Echo(Localize("Axiom auto login failed"));
+		}
+	}
+}
+
+void CTClient::UpdateAxiomAutoLogin()
+{
+	if(Client()->State() != IClient::STATE_ONLINE || g_Config.m_QmAxiomAutoLogin == 0 || g_Config.m_QmAxiomLoginPassword[0] == '\0')
+	{
+		ResetAxiomAutoLoginState();
+		return;
+	}
+	if(!IsAxiomCommunity())
+	{
+		ResetAxiomAutoLoginState();
+		return;
+	}
+
+	char aServerAddress[NETADDR_MAXSTRSIZE] = "";
+	net_addr_str(&Client()->ServerAddress(), aServerAddress, sizeof(aServerAddress), true);
+	if(m_aAxiomAutoLoginServer[0] != '\0' && aServerAddress[0] != '\0' && str_comp(m_aAxiomAutoLoginServer, aServerAddress) != 0)
+		ResetAxiomAutoLoginState();
+
+	if(m_AxiomAutoLoginSucceeded || m_AxiomAutoLoginWaitingReply)
+		return;
+
+	const int64_t Now = time_get();
+	if(m_AxiomAutoLoginAttempts == 0 || (m_AxiomAutoLoginNextTryTick > 0 && Now >= m_AxiomAutoLoginNextTryTick))
+		TrySendAxiomLogin();
+}
+
 void CTClient::OnMessage(int MsgType, void *pRawMsg)
 {
 	if(Client()->State() == IClient::STATE_DEMOPLAYBACK)
@@ -1660,6 +1797,7 @@ void CTClient::OnMessage(int MsgType, void *pRawMsg)
 			if(pMsg->m_pMessage)
 			{
 				const char *pText = pMsg->m_pMessage;
+				HandleAxiomAutoLoginMessage(pText);
 				if(str_find_nocase(pText, "has requested to swap with you"))
 				{
 					StartSwapCountdown();
@@ -1958,7 +2096,7 @@ void CTClient::AirRescue()
 		return;
 	if(GameClient()->m_Snap.m_aCharacters[ClientId].m_HasExtendedDisplayInfo && (GameClient()->m_Snap.m_aCharacters[ClientId].m_ExtendedData.m_Flags & CHARACTERFLAG_PRACTICE_MODE) == 0)
 	{
-		GameClient()->Echo("You are not in practice");
+		GameClient()->Echo(Localize("You are not in practice"));
 		return;
 	}
 
@@ -1994,7 +2132,7 @@ void CTClient::AirRescue()
 		return;
 	}
 
-	GameClient()->Echo("No safe position found");
+	GameClient()->Echo(Localize("No safe position found"));
 }
 
 void CTClient::ConAirRescue(IConsole::IResult *pResult, void *pUserData)
@@ -2308,6 +2446,7 @@ void CTClient::OnUpdate()
 	MaybeSaveMapCategoryCache();
 	ApplyFocusModeEffects();
 	ApplyGoresFastInputLink();
+	UpdateAxiomAutoLogin();
 }
 
 void CTClient::OnRender()
@@ -2858,7 +2997,12 @@ void CTClient::ResetQmClientRecognitionTasks()
 
 bool CTClient::NeedsQmClientRecognition() const
 {
-	return g_Config.m_QmVoiceServer[0] != '\0';
+	return HasQmClientRecognitionService();
+}
+
+bool CTClient::HasQmClientRecognitionService() const
+{
+	return GetEffectiveQmVoiceServer()[0] != '\0';
 }
 
 bool CTClient::NeedsFastQmClientSync() const
@@ -2870,12 +3014,11 @@ bool CTClient::BuildQmClientRecognitionUrl(const char *pPath, char *pBuf, size_t
 {
 	if(!pPath || pPath[0] == '\0' || !pBuf || BufSize == 0)
 		return false;
-	if(g_Config.m_QmVoiceServer[0] == '\0')
-		return false;
 
+	const char *pVoiceServer = GetEffectiveQmVoiceServer();
 	char aHost[128];
 	int Port = 0;
-	if(!ParseQmClientServiceHostPort(g_Config.m_QmVoiceServer, aHost, sizeof(aHost), Port))
+	if(!ParseQmClientServiceHostPort(pVoiceServer, aHost, sizeof(aHost), Port))
 		return false;
 
 	const bool NeedsIpv6Brackets = str_find(aHost, ":") != nullptr;
@@ -3201,7 +3344,7 @@ void CTClient::UpdateQmClientRecognition()
 		m_pQmClientUsersSendTask = nullptr;
 	}
 
-	const bool NeedRecognition = g_Config.m_QmVoiceServer[0] != '\0';
+	const bool NeedRecognition = NeedsQmClientRecognition();
 	if(!NeedRecognition)
 	{
 		if(m_pQmClientAuthTokenTask || m_pQmClientUsersTask || m_pQmClientUsersSendTask || m_pQmClientUsersParseJob || m_aQmClientAuthToken[0] != '\0' || m_QmClientLastSync != 0)
@@ -4370,6 +4513,7 @@ void CTClient::OnStateChange(int NewState, int OldState)
 
 	if(NewState != IClient::STATE_ONLINE)
 	{
+		ResetAxiomAutoLoginState();
 		ClearSwapCountdown();
 		m_aLastChatMessage[0] = '\0';
 		m_LastRepeatTime = 0;
@@ -4398,6 +4542,9 @@ void CTClient::OnStateChange(int NewState, int OldState)
 	}
 	m_aLastGameplayLogicTick[0] = -1;
 	m_aLastGameplayLogicTick[1] = -1;
+
+	if(NewState == IClient::STATE_ONLINE)
+		ResetAxiomAutoLoginState();
 
 	// 进入服务器时重置统计数据
 	if(NewState == IClient::STATE_ONLINE && g_Config.m_QmPlayerStatsResetOnJoin)
@@ -4744,6 +4891,11 @@ bool CTClient::IsGoresGameMode() const
 bool CTClient::IsGoresModuleEnabled() const
 {
 	return g_Config.m_QmGores != 0 || (g_Config.m_QmGoresAutoEnable != 0 && IsGoresGameMode());
+}
+
+bool CTClient::ShouldHideGoresGuides() const
+{
+	return IsGoresModuleEnabled() && g_Config.m_QmGoresHideGuides != 0;
 }
 
 bool CTClient::HasBlockingGoresWeapon() const
@@ -5098,8 +5250,29 @@ void CTClient::BuildGoresDistanceField()
 void CTClient::ApplyFocusModeEffects()
 {
 	const bool FocusActive = g_Config.m_QmFocusMode != 0;
+	const bool StateWasKnown = m_FocusModeStateKnown;
+	if(!m_FocusModeStateKnown)
+	{
+		m_FocusModeStateKnown = true;
+		if(!FocusActive)
+		{
+			m_PrevFocusModeActive = false;
+			return;
+		}
+		m_PrevFocusModeActive = false;
+	}
 	if(FocusActive == m_PrevFocusModeActive)
 		return;
+
+	if(StateWasKnown)
+	{
+		char aFocusMsg[128];
+		str_format(aFocusMsg, sizeof(aFocusMsg), "%s%s: %s",
+			FocusActive ? "[[$FF7F7F]]" : "[[$A5FFA5]]",
+			Localize("Focus Mode"),
+			Localize(FocusActive ? "On" : "Off"));
+		GameClient()->Echo(aFocusMsg);
+	}
 
 	if(FocusActive)
 	{
@@ -5111,13 +5284,16 @@ void CTClient::ApplyFocusModeEffects()
 		if(g_Config.m_QmFocusModeHideNames)
 		{
 			m_SavedClNamePlates = g_Config.m_ClNamePlates;
+			m_SavedClNamePlatesOwn = g_Config.m_ClNamePlatesOwn;
 			g_Config.m_ClNamePlates = 0;
+			g_Config.m_ClNamePlatesOwn = 0;
 		}
 	}
 	else
 	{
 		g_Config.m_ClShowhud = m_SavedClShowhud;
 		g_Config.m_ClNamePlates = m_SavedClNamePlates;
+		g_Config.m_ClNamePlatesOwn = m_SavedClNamePlatesOwn;
 	}
 
 	m_PrevFocusModeActive = FocusActive;
@@ -5126,6 +5302,31 @@ void CTClient::ApplyFocusModeEffects()
 void CTClient::ApplyGoresFastInputLink()
 {
 	const bool GoresActive = g_Config.m_QmGores != 0;
+	const bool StateWasKnown = m_GoresModeStateKnown;
+	if(!m_GoresModeStateKnown)
+	{
+		m_GoresModeStateKnown = true;
+		if(!GoresActive)
+		{
+			m_PrevGoresModeActive = false;
+			return;
+		}
+		m_PrevGoresModeActive = false;
+	}
+	if(GoresActive != m_PrevGoresModeActive)
+	{
+		if(StateWasKnown)
+		{
+			char aGoresMsg[128];
+			str_format(aGoresMsg, sizeof(aGoresMsg), "%s%s: %s",
+				GoresActive ? "[[$FF7F7F]]" : "[[$A5FFA5]]",
+				Localize("Gores Mode"),
+				Localize(GoresActive ? "On" : "Off"));
+			GameClient()->Echo(aGoresMsg);
+		}
+		m_PrevGoresModeActive = GoresActive;
+	}
+
 	const bool ShouldEnableFastInput = GoresActive && g_Config.m_QmGoresFastInput;
 	const bool ShouldEnableFastInputOthers = ShouldEnableFastInput && g_Config.m_QmGoresFastInputOthers;
 
@@ -5299,7 +5500,7 @@ bool CTClient::BuildGoresDebugRoute(std::vector<vec2> &vRoutePoints, int Dummy) 
 
 void CTClient::RenderGoresDebugRoute()
 {
-	if(Client()->State() != IClient::STATE_ONLINE || !IsGoresMapProgressDebugRouteEnabled())
+	if(Client()->State() != IClient::STATE_ONLINE || !IsGoresMapProgressDebugRouteEnabled() || ShouldHideGoresGuides())
 		return;
 
 	EnsureGoresDistanceField();
@@ -5667,7 +5868,7 @@ void CTClient::ConSaveList(IConsole::IResult *pResult, void *pUserData)
 	IOHANDLE File = pThis->Storage()->OpenFile(SAVES_FILE, IOFLAG_READ, IStorage::TYPE_SAVE);
 	if(!File)
 	{
-		pThis->GameClient()->Echo("No local saves file found (ddnet-saves.txt)");
+		pThis->GameClient()->Echo(Localize("No local saves file found (ddnet-saves.txt)"));
 		return;
 	}
 
@@ -5677,7 +5878,7 @@ void CTClient::ConSaveList(IConsole::IResult *pResult, void *pUserData)
 
 	if(!pFileContent)
 	{
-		pThis->GameClient()->Echo("Failed to read saves file");
+		pThis->GameClient()->Echo(Localize("Failed to read saves file"));
 		return;
 	}
 

--- a/src/game/client/components/qmclient/qmclient.h
+++ b/src/game/client/components/qmclient/qmclient.h
@@ -133,6 +133,11 @@ class CTClient : public CComponent
 	float m_FinishTextTimeout = 0.0f;
 	void DoFinishCheck();
 	const char *CurrentCommunityIdForFinishCheck() const;
+	bool IsAxiomCommunity() const;
+	void ResetAxiomAutoLoginState();
+	void UpdateAxiomAutoLogin();
+	void HandleAxiomAutoLoginMessage(const char *pText);
+	void TrySendAxiomLogin();
 	void StartUpdateDownload();
 	void ResetUpdateExeTask();
 	bool ReplaceClientFromUpdate();
@@ -367,6 +372,7 @@ class CTClient : public CComponent
 
 public:
 	CTClient();
+	bool HasQmClientRecognitionService() const;
 	int Sizeof() const override { return sizeof(*this); }
 	void OnInit() override;
 	void OnShutdown() override;
@@ -435,6 +441,7 @@ public:
 	int QmDdnetTotalFinishes() const { return m_QmDdnetTotalFinishes; }
 	const char *QmDdnetFavoritePartner() const { return m_aQmDdnetFavoritePartner; }
 	bool IsGoresMapProgressEnabled() const;
+	bool ShouldHideGoresGuides() const;
 	bool HasGoresMapProgress(int Dummy = 0) const
 	{
 		const int Idx = Dummy < 0 ? 0 : (Dummy >= NUM_DUMMIES ? NUM_DUMMIES - 1 : Dummy);
@@ -447,16 +454,26 @@ public:
 	}
 
 	// Focus Mode (Zen Mode)
+	bool m_FocusModeStateKnown = false;
 	bool m_PrevFocusModeActive = false;
 	int m_SavedClShowhud = 1;
 	int m_SavedClNamePlates = 1;
+	int m_SavedClNamePlatesOwn = 1;
 	void ApplyFocusModeEffects();
 
 	// Gores FastInput Link
+	bool m_GoresModeStateKnown = false;
+	bool m_PrevGoresModeActive = false;
 	bool m_PrevGoresFastInputActive = false;
 	int m_SavedTcFastInput = 0;
 	bool m_PrevGoresFastInputOthersActive = false;
 	int m_SavedTcFastInputOthers = 0;
+	bool m_AxiomAutoLoginAnnounced = false;
+	bool m_AxiomAutoLoginSucceeded = false;
+	bool m_AxiomAutoLoginWaitingReply = false;
+	int m_AxiomAutoLoginAttempts = 0;
+	int64_t m_AxiomAutoLoginNextTryTick = 0;
+	char m_aAxiomAutoLoginServer[NETADDR_MAXSTRSIZE] = "";
 	void ApplyGoresFastInputLink();
 
 };

--- a/src/game/client/components/qmclient/translate.cpp
+++ b/src/game/client/components/qmclient/translate.cpp
@@ -999,13 +999,13 @@ void CTranslate::Translate(int Id, bool ShowProgress)
 {
 	if(Id < 0 || Id >= (int)std::size(GameClient()->m_aClients))
 	{
-		GameClient()->m_Chat.Echo("Not a valid ID");
+		GameClient()->m_Chat.Echo(Localize("Not a valid ID"));
 		return;
 	}
 	const auto &Player = GameClient()->m_aClients[Id];
 	if(!Player.m_Active)
 	{
-		GameClient()->m_Chat.Echo("ID not connected");
+		GameClient()->m_Chat.Echo(Localize("ID not connected"));
 		return;
 	}
 	Translate(Player.m_aName, ShowProgress);
@@ -1048,7 +1048,7 @@ void CTranslate::Translate(const char *pName, bool ShowProgress)
 	}
 	if(!pLineBest || pLineBest->m_aText[0] == '\0')
 	{
-		GameClient()->m_Chat.Echo("No message to translate");
+		GameClient()->m_Chat.Echo(Localize("No message to translate"));
 		return;
 	}
 
@@ -1064,7 +1064,7 @@ void CTranslate::Translate(CChat::CLine &Line, bool ShowProgress, bool AutoTrigg
 	if(Line.m_ClientId == CChat::SERVER_MSG)
 	{
 		if(ShowProgress)
-			GameClient()->m_Chat.Echo("Server messages are not translated");
+			GameClient()->m_Chat.Echo(Localize("Server messages are not translated"));
 		return;
 	}
 
@@ -1077,7 +1077,7 @@ void CTranslate::Translate(CChat::CLine &Line, bool ShowProgress, bool AutoTrigg
 	Job.m_pBackend = CreateTranslateBackend(*Http(), Job.m_pLine->m_aText, Job.m_aTarget);
 	if(!Job.m_pBackend)
 	{
-		GameClient()->m_Chat.Echo("Invalid translate backend");
+		GameClient()->m_Chat.Echo(Localize("Invalid translate backend"));
 		return;
 	}
 
@@ -1106,7 +1106,7 @@ bool CTranslate::TryTranslateOutgoingChat(int Team, const char *pText)
 
 	if(m_vJobs.size() + m_vOutgoingJobs.size() > MAX_TRANSLATION_JOBS)
 	{
-		GameClient()->m_Chat.Echo("Too many translation jobs");
+		GameClient()->m_Chat.Echo(Localize("Too many translation jobs"));
 		return true;
 	}
 
@@ -1116,12 +1116,12 @@ bool CTranslate::TryTranslateOutgoingChat(int Team, const char *pText)
 	Job.m_pBackend = CreateTranslateBackend(*Http(), Text.c_str(), Job.m_aTarget);
 	if(!Job.m_pBackend)
 	{
-		GameClient()->m_Chat.Echo("Invalid translate backend");
+		GameClient()->m_Chat.Echo(Localize("Invalid translate backend"));
 		return true;
 	}
 
 	char aBuf[128];
-	str_format(aBuf, sizeof(aBuf), "%s translating to %s before send", Job.m_pBackend->Name(), Job.m_aTarget);
+	str_format(aBuf, sizeof(aBuf), Localize("%s translating to %s before send"), Job.m_pBackend->Name(), Job.m_aTarget);
 	GameClient()->m_Chat.Echo(aBuf);
 	m_vOutgoingJobs.emplace_back(std::move(Job));
 	return true;

--- a/src/game/client/components/qmclient/voice_core.cpp
+++ b/src/game/client/components/qmclient/voice_core.cpp
@@ -1,4 +1,5 @@
 #include "voice_core.h"
+#include "qmclient.h"
 #include "voice_utils.h"
 
 #include <base/log.h>
@@ -37,6 +38,8 @@ static constexpr int VOICE_CONFIG_SNAPSHOT_INTERVAL_MS = 50;
 static constexpr int VOICE_OVERLAY_VISIBLE_MS = 180;
 static constexpr int VOICE_OVERLAY_MAX_SPEAKERS = 5;
 static constexpr const char *s_pVoiceOverlayMicIcon = "\xEF\x84\xB0";
+
+const char *GetEffectiveQmVoiceServer();
 
 // !!WARNING!!
 // Voice full wrote by AI don't use that pls
@@ -1217,12 +1220,13 @@ void CRClientVoice::Shutdown()
 
 void CRClientVoice::UpdateServerAddrConfig()
 {
+	const char *pVoiceServer = GetEffectiveQmVoiceServer();
 	bool AddrChanged = false;
 	{
 		std::lock_guard<std::mutex> Guard(m_ServerAddrMutex);
-		AddrChanged = str_comp(m_aServerAddrStr, g_Config.m_QmVoiceServer) != 0;
+		AddrChanged = str_comp(m_aServerAddrStr, pVoiceServer) != 0;
 		if(AddrChanged)
-			str_copy(m_aServerAddrStr, g_Config.m_QmVoiceServer, sizeof(m_aServerAddrStr));
+			str_copy(m_aServerAddrStr, pVoiceServer, sizeof(m_aServerAddrStr));
 	}
 
 	if(!AddrChanged)


### PR DESCRIPTION
## Summary\n- 完成 QmClient 设置页/状态栏/资源页的切页与交互优化，并补充相关中文本地化\n- 增加 Focus Mode / Gores 的可见性控制、Axiom 自动登录和识别服务相关改动\n- 适配 upstream/master 的差异，保留可编译的最小修正\n\n## Verification\n- Windows: qmclient_scripts\\cmake-windows.cmd --build build-ninja --target game-client -j 10\n