### PR TITLE
ci(nightly): 改用中文发布说明

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -574,12 +574,10 @@ jobs:
         shell: bash
         run: |
           {
-            echo "# QmClient Nightly"
-            echo
-            echo "- Commit: ${GITHUB_SHA}"
-            echo "- Source branch: ${GITHUB_REF_NAME}"
-            echo "- Built at: $(date -u +'%Y-%m-%d %H:%M:%S UTC')"
-            echo "- This is an internal testing build and may be replaced by the next nightly run."
+            echo "- 提交：${GITHUB_SHA}"
+            echo "- 来源分支：${GITHUB_REF_NAME}"
+            echo "- 构建时间：$(date -u +'%Y-%m-%d %H:%M:%S UTC')"
+            echo "- 说明：这是内部测试构建，可能会被下一次 nightly 构建替换。"
           } > release-assets/nightly-notes.md
 
       - name: Replace nightly prerelease


### PR DESCRIPTION
## Summary
nightly release 页面正文去掉重复标题，并将构建信息说明改成中文。

## ci
- 移除 nightly notes 里的正文 H1，避免和 GitHub release 标题重复。
- 将提交、来源分支、构建时间和测试构建说明改为中文。

## Verification
- [x] nightly workflow YAML 解析通过。
- [x] 空白检查：`git diff --check`
- [x] 文档检查：`python qmclient_scripts/gate/check_docs.py --sync-only --prefer agents`、`python qmclient_scripts/gate/check_docs.py` 

## Risks / Gaps
- 未重新等待完整 nightly 构建完成；这次只改 release notes 文案。