### PR TITLE
ci(nightly): 对齐发布说明格式

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -574,10 +574,25 @@ jobs:
         shell: bash
         run: |
           {
-            echo "- 提交：${GITHUB_SHA}"
-            echo "- 来源分支：${GITHUB_REF_NAME}"
-            echo "- 构建时间：$(date -u +'%Y-%m-%d %H:%M:%S UTC')"
-            echo "- 说明：这是内部测试构建，可能会被下一次 nightly 构建替换。"
+            echo "# 更新日志"
+            echo "> Version: nightly"
+            echo "> Commit: ${GITHUB_SHA}"
+            echo "> Branch: ${GITHUB_REF_NAME}"
+            echo "> Built at: $(date -u +'%Y-%m-%d %H:%M:%S UTC')"
+            echo
+            echo "##feat."
+            echo "- nightly: 这是内部测试构建，包含当前分支的最新提交，可能会被下一次 nightly 构建替换。"
+            echo
+            echo "## fix"
+            echo "- None"
+            echo
+            echo "# What's Changed"
+            echo
+            echo "## feat."
+            echo "- nightly: Internal testing build for the latest commits on the current branch. It may be replaced by the next nightly run."
+            echo
+            echo "## fix"
+            echo "- None"
           } > release-assets/nightly-notes.md
 
       - name: Replace nightly prerelease


### PR DESCRIPTION
## Summary
nightly release notes 改为接近正式 release notes 的中英双段 Markdown 结构，同时保留 nightly 的构建元信息。

## ci
- 使用 # 更新日志 / # What's Changed 结构对齐正式发布说明。
- 保留 Version: nightly、commit、branch、built at 和内部测试构建说明。

## Verification
- [x] nightly workflow YAML 解析通过。
- [x] 空白检查：`git diff --check`
- [x] 文档检查：`python qmclient_scripts/gate/check_docs.py --sync-only --prefer agents`、`python qmclient_scripts/gate/check_docs.py` 

## Risks / Gaps
- 未等待完整 nightly 构建；这次只改 release notes 文案格式。