### PR TITLE
build(deps): webp 预编译库并入 ddnet-libs，全平台改用自带库

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,47 +155,6 @@ jobs:
               }
             }
 
-      - name: Cache WebP for Windows
-        if: runner.os == 'Windows'
-        id: cache-webp-windows
-        uses: actions/cache@v5
-        with:
-          path: |
-            ddnet-libs/webp/include
-            ddnet-libs/webp/windows
-          key: webp-windows-v1.6.0-${{ hashFiles('.github/workflows/build.yml') }}
-          restore-keys: webp-windows-v1.6.0-
-
-      - name: Build WebP for Windows
-        if: runner.os == 'Windows' && steps.cache-webp-windows.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          WORK_DIR="$(mktemp -d)"
-          trap 'rm -rf "$WORK_DIR"' EXIT
-
-          git clone --depth 1 --branch v1.6.0 https://chromium.googlesource.com/webm/libwebp "$WORK_DIR/libwebp"
-          cmake -S "$WORK_DIR/libwebp" -B "$WORK_DIR/build" -G Ninja \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_INSTALL_PREFIX="$WORK_DIR/install" \
-            -DBUILD_SHARED_LIBS=OFF \
-            -DWEBP_BUILD_ANIM_UTILS=OFF \
-            -DWEBP_BUILD_CWEBP=OFF \
-            -DWEBP_BUILD_DWEBP=OFF \
-            -DWEBP_BUILD_EXTRAS=OFF \
-            -DWEBP_BUILD_GIF2WEBP=OFF \
-            -DWEBP_BUILD_IMG2WEBP=OFF \
-            -DWEBP_BUILD_VWEBP=OFF \
-            -DWEBP_BUILD_WEBPINFO=OFF \
-            -DWEBP_BUILD_WEBPMUX=OFF \
-            -DWEBP_BUILD_WEBP_JS=OFF
-          cmake --build "$WORK_DIR/build" --parallel
-          cmake --install "$WORK_DIR/build"
-
-          mkdir -p ddnet-libs/webp/include ddnet-libs/webp/windows/lib64
-          cp -R "$WORK_DIR/install/include/webp" ddnet-libs/webp/include/
-          cp "$WORK_DIR/install/lib/"*.lib ddnet-libs/webp/windows/lib64/
-
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
         run: |
@@ -207,7 +166,7 @@ jobs:
             libvulkan-dev glslang-tools spirv-tools \
             libavcodec-dev libavformat-dev libavutil-dev \
             libswresample-dev libswscale-dev libx264-dev \
-            libpng-dev libwebp-dev libcurl4-openssl-dev libssl-dev \
+            libpng-dev libcurl4-openssl-dev libssl-dev \
             libogg-dev libopus-dev libopusfile-dev libwavpack-dev
 
       - name: Install macOS dependencies
@@ -217,7 +176,7 @@ jobs:
           for tap in aws/tap azure/bicep; do
             brew untap "$tap" 2>/dev/null || true
           done
-          for pkg in cmake ninja pkg-config python freetype sdl2 libpng webp libogg opus opusfile sqlite wavpack ffmpeg molten-vk vulkan-loader glslang; do
+          for pkg in cmake ninja pkg-config python freetype sdl2 libpng libogg opus opusfile sqlite wavpack ffmpeg molten-vk vulkan-loader glslang; do
             if brew list --formula "$pkg" &>/dev/null; then
               brew link --overwrite "$pkg" 2>/dev/null || true
             else
@@ -503,80 +462,6 @@ jobs:
             "ndk;${{ env.ANDROID_NDK_VERSION }}"
           yes | sdkmanager --licenses
 
-      - name: Cache WebP for Android
-        id: cache-webp
-        uses: actions/cache@v5
-        with:
-          path: ddnet-libs/webp/android
-          key: webp-android-v1.6.0-sharpyuv-${{ hashFiles('.github/workflows/build.yml', 'ddnet-libs/webp/**') }}
-          restore-keys: webp-android-v1.6.0-sharpyuv-
-
-      - name: Build WebP for Android (Parallel)
-        if: steps.cache-webp.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          git clone --depth 1 --branch v1.6.0 https://chromium.googlesource.com/webm/libwebp
-          cd libwebp
-          
-          ANDROID_NDK_HOME="$ANDROID_HOME/ndk/${{ env.ANDROID_NDK_VERSION }}"
-          
-          # Build all ABIs in parallel using background jobs
-          build_abi() {
-            local ABI=$1
-            local DIR=$2
-            mkdir -p "build-android/${ABI}"
-            cmake -S . -B "build-android/${ABI}" \
-              -G Ninja \
-              -DCMAKE_TOOLCHAIN_FILE="${ANDROID_NDK_HOME}/build/cmake/android.toolchain.cmake" \
-              -DANDROID_ABI="${ABI}" \
-              -DANDROID_PLATFORM=android-24 \
-              -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_INSTALL_PREFIX="${PWD}/install-${ABI}" \
-              -DWEBP_BUILD_ANIM_UTILS=OFF \
-              -DWEBP_BUILD_CWEBP=OFF \
-              -DWEBP_BUILD_DWEBP=OFF \
-              -DWEBP_BUILD_EXTRAS=OFF \
-              -DWEBP_BUILD_GIF2WEBP=OFF \
-              -DWEBP_BUILD_IMG2WEBP=OFF \
-              -DWEBP_BUILD_VWEBP=OFF \
-              -DWEBP_BUILD_WEBPINFO=OFF \
-              -DWEBP_BUILD_WEBPMUX=OFF \
-              -DWEBP_BUILD_WEBP_JS=OFF 2>&1 | tee "build-${ABI}.log"
-            cmake --build "build-android/${ABI}" --parallel 2>&1 | tee -a "build-${ABI}.log"
-            cmake --install "build-android/${ABI}" 2>&1 | tee -a "build-${ABI}.log"
-            echo "Completed ${ABI}"
-          }
-          
-          # Start all builds in parallel
-          build_abi armeabi-v7a libarm &
-          build_abi arm64-v8a libarm64 &
-          build_abi x86 lib32 &
-          build_abi x86_64 lib64 &
-          
-          # Wait for all background jobs
-          wait
-          
-          # Copy to ddnet-libs
-          mkdir -p ../ddnet-libs/webp/include/webp
-          cp -r install-arm64-v8a/include/webp/* ../ddnet-libs/webp/include/webp/
-          
-          for ABI in armeabi-v7a arm64-v8a x86 x86_64; do
-            case "${ABI}" in
-              armeabi-v7a) DIR="libarm" ;;
-              arm64-v8a) DIR="libarm64" ;;
-              x86) DIR="lib32" ;;
-              x86_64) DIR="lib64" ;;
-            esac
-            mkdir -p "../ddnet-libs/webp/android/${DIR}"
-            cp "install-${ABI}/lib/libwebp.a" "../ddnet-libs/webp/android/${DIR}/"
-            cp "install-${ABI}/lib/libwebpdemux.a" "../ddnet-libs/webp/android/${DIR}/" 2>/dev/null || true
-            cp "install-${ABI}/lib/libwebpmux.a" "../ddnet-libs/webp/android/${DIR}/" 2>/dev/null || true
-            cp "install-${ABI}/lib/libsharpyuv.a" "../ddnet-libs/webp/android/${DIR}/" 2>/dev/null || true
-          done
-          
-          echo "All WebP builds completed"
-
       - name: Prepare Android signing keystore
         shell: bash
         env:
@@ -632,17 +517,6 @@ jobs:
           cp "${ANDROID_BUILD_DIR}/${ANDROID_APP_NAME}.apk" dist/QmClient-android.apk
           cp "${ANDROID_BUILD_DIR}/${ANDROID_APP_NAME}.aab" dist/QmClient-android.aab
           ls -lah dist
-
-      - name: Upload WebP libraries (for ddnet-libs)
-        if: steps.cache-webp.outputs.cache-hit != 'true'
-        uses: actions/upload-artifact@v6
-        with:
-          name: webp-android-libs
-          path: |
-            ddnet-libs/webp/android/
-            ddnet-libs/webp/include/
-          if-no-files-found: ignore
-          retention-days: 30
 
       - name: Upload Android artifact
         uses: actions/upload-artifact@v6

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -163,7 +163,7 @@ jobs:
             libvulkan-dev glslang-tools spirv-tools \
             libavcodec-dev libavformat-dev libavutil-dev \
             libswresample-dev libswscale-dev libx264-dev \
-            libpng-dev libwebp-dev libcurl4-openssl-dev libssl-dev \
+            libpng-dev libcurl4-openssl-dev libssl-dev \
             libogg-dev libopus-dev libopusfile-dev libwavpack-dev
 
       - name: Install macOS dependencies
@@ -173,7 +173,7 @@ jobs:
           for tap in aws/tap azure/bicep; do
             brew untap "$tap" 2>/dev/null || true
           done
-          for pkg in cmake ninja pkg-config python freetype sdl2 libpng webp libogg opus opusfile sqlite wavpack ffmpeg molten-vk vulkan-loader glslang; do
+          for pkg in cmake ninja pkg-config python freetype sdl2 libpng libogg opus opusfile sqlite wavpack ffmpeg molten-vk vulkan-loader glslang; do
             if brew list --formula "$pkg" &>/dev/null; then
               brew link --overwrite "$pkg" 2>/dev/null || true
             else
@@ -431,75 +431,6 @@ jobs:
             "build-tools;36.1.0" \
             "ndk;${{ env.ANDROID_NDK_VERSION }}"
           yes | sdkmanager --licenses
-
-      - name: Cache WebP for Android
-        id: cache-webp
-        uses: actions/cache@v5
-        with:
-          path: ddnet-libs/webp/android
-          key: nightly-webp-android-v1.6.0-sharpyuv-${{ hashFiles('.github/workflows/nightly.yml', 'ddnet-libs/webp/**') }}
-          restore-keys: nightly-webp-android-v1.6.0-sharpyuv-
-
-      - name: Build WebP for Android (Parallel)
-        if: steps.cache-webp.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          git clone --depth 1 --branch v1.6.0 https://chromium.googlesource.com/webm/libwebp
-          cd libwebp
-
-          ANDROID_NDK_HOME="$ANDROID_HOME/ndk/${{ env.ANDROID_NDK_VERSION }}"
-
-          build_abi() {
-            local ABI=$1
-            local DIR=$2
-            mkdir -p "build-android/${ABI}"
-            cmake -S . -B "build-android/${ABI}" \
-              -G Ninja \
-              -DCMAKE_TOOLCHAIN_FILE="${ANDROID_NDK_HOME}/build/cmake/android.toolchain.cmake" \
-              -DANDROID_ABI="${ABI}" \
-              -DANDROID_PLATFORM=android-24 \
-              -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_INSTALL_PREFIX="${PWD}/install-${ABI}" \
-              -DWEBP_BUILD_ANIM_UTILS=OFF \
-              -DWEBP_BUILD_CWEBP=OFF \
-              -DWEBP_BUILD_DWEBP=OFF \
-              -DWEBP_BUILD_EXTRAS=OFF \
-              -DWEBP_BUILD_GIF2WEBP=OFF \
-              -DWEBP_BUILD_IMG2WEBP=OFF \
-              -DWEBP_BUILD_VWEBP=OFF \
-              -DWEBP_BUILD_WEBPINFO=OFF \
-              -DWEBP_BUILD_WEBPMUX=OFF \
-              -DWEBP_BUILD_WEBP_JS=OFF 2>&1 | tee "build-${ABI}.log"
-            cmake --build "build-android/${ABI}" --parallel 2>&1 | tee -a "build-${ABI}.log"
-            cmake --install "build-android/${ABI}" 2>&1 | tee -a "build-${ABI}.log"
-            echo "Completed ${ABI}"
-          }
-
-          build_abi armeabi-v7a libarm &
-          build_abi arm64-v8a libarm64 &
-          build_abi x86 lib32 &
-          build_abi x86_64 lib64 &
-          wait
-
-          mkdir -p ../ddnet-libs/webp/include/webp
-          cp -r install-arm64-v8a/include/webp/* ../ddnet-libs/webp/include/webp/
-
-          for ABI in armeabi-v7a arm64-v8a x86 x86_64; do
-            case "${ABI}" in
-              armeabi-v7a) DIR="libarm" ;;
-              arm64-v8a) DIR="libarm64" ;;
-              x86) DIR="lib32" ;;
-              x86_64) DIR="lib64" ;;
-            esac
-            mkdir -p "../ddnet-libs/webp/android/${DIR}"
-            cp "install-${ABI}/lib/libwebp.a" "../ddnet-libs/webp/android/${DIR}/"
-            cp "install-${ABI}/lib/libwebpdemux.a" "../ddnet-libs/webp/android/${DIR}/" 2>/dev/null || true
-            cp "install-${ABI}/lib/libwebpmux.a" "../ddnet-libs/webp/android/${DIR}/" 2>/dev/null || true
-            cp "install-${ABI}/lib/libsharpyuv.a" "../ddnet-libs/webp/android/${DIR}/" 2>/dev/null || true
-          done
-
-          echo "All WebP builds completed"
 
       - name: Prepare Android signing keystore
         shell: bash

--- a/cmake/FindWebP.cmake
+++ b/cmake/FindWebP.cmake
@@ -1,3 +1,10 @@
+# QmClient：全平台优先使用 ddnet-libs 自带的预编译 webp（自包含，不依赖系统包），
+# 自带库缺失时回退到系统包（pkg-config）。
+if(TARGET_OS AND TARGET_BITS)
+  set(HINTS_WebP_LIBDIR "ddnet-libs/webp/${LIB_DIR}")
+  set(HINTS_WebP_INCLUDEDIR "ddnet-libs/webp/include")
+endif()
+
 if(NOT PREFER_BUNDLED_LIBS)
   find_package(PkgConfig QUIET)
   if(PkgConfig_FOUND)
@@ -68,9 +75,8 @@ if(WebP_LIBRARY AND WebP_INCLUDEDIR)
   if(WebP_SHARPYUV_LIBRARY)
     list(APPEND WebP_LIBRARIES ${WebP_SHARPYUV_LIBRARY})
   endif()
-  if(NOT WebP_INCLUDE_DIRS)
-    set(WebP_INCLUDE_DIRS ${WebP_INCLUDEDIR})
-  endif()
+  # 优先使用 find_path 找到的头文件目录（自带库优先），避免与 pkg-config 的系统头混用
+  set(WebP_INCLUDE_DIRS ${WebP_INCLUDEDIR})
 endif()
 
 if(WebP_FOUND)


### PR DESCRIPTION
## 变更说明

将 libwebp v1.6.0 预编译库（Windows / Linux / macOS / Android，含 sharpyuv）补齐进 ddnet-libs 子模块，并让 webp 在所有平台优先使用自带库——不再依赖 CI 机器/开发机上的系统包（apt/brew），也不再由 CI 现场编译。

## 改动内容

### build

- ddnet-libs 子模块 0b785e5a → 0f475a8：补齐 libwebp v1.6.0 全平台预编译库（windows/lib64、android/{lib32,lib64,libarm,libarm64}、linux/lib64、mac/libarm64 的 .lib/.a，含 sharpyuv），替换原占位符；README 增加 WebP 说明。
- cmake/FindWebP.cmake：全平台优先搜索 ddnet-libs/webp 自带库（HINTS），系统包仅作回退；头文件目录以 find_path 结果为准，避免与系统头混用。

### ci

- build.yml / nightly.yml：删除 Windows / Android / Linux 的 webp 现场编译与缓存/上传步骤。
- 移除 CI 中 apt 的 libwebp-dev 与 brew 的 webp 系统包安装。

## 测试方法

1. macOS 本机配置验证：`cmake -S . -B tmp/verify ...` 输出 `Found WebP: ddnet-libs/webp/mac/libarm64/libwebp.a`（自带库优先于 brew 系统库）。
2. CI 产物核对：webp-windows-libs（本 PR 前置 run）、webp-linux-libs（CI 编译）与 android 产物（同 workflow 正式 run）均已下载并组装进 ddnet-libs。
3. 本 PR 的 build.yml CI 将全平台（Windows/Linux/macOS/Android）使用自带 webp 构建验证。

## 检查清单

- [x] 已自查代码，无明显错误
- [x] 代码风格符合项目规范
- [x] 本地验证通过（macOS configure 确认自带库优先）
- [ ] 不引入新的编译警告（待 PR CI 确认）
- [x] 无未处理的 FIXME / TODO / HACK 标记

## Risks / Gaps

- PR CI 的 Windows/macOS "Run tests" 步骤当前在 master 上已存在失败（testrunner 链接重复符号 `CUi::PixelSize`，与本次改动无关），属 pre-existing 问题。
- 仅覆盖 CI 实际构建的架构（linux/lib64、mac/libarm64）；其他架构（如 linux arm64、mac x86_64）走系统包回退。